### PR TITLE
New property `version` added to proxyOptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,17 @@
 
 ## [Unreleased]
 
+## [2.1.0] - 2026-07-16
+
 ### Added
 
 - **`mcpose`** — `BackendConfig` gains a `headers` property (`Record<string, string>`); the headers are sent on every request to the backend (HTTP/SSE only), so the upstream client can pass headers through.
 - **`mcpose`** — `BackendConfig` gains an `authProvider` property (`OAuthClientProvider` from the MCP SDK); when set, the HTTP/SSE transport drives the MCP OAuth flow (interactive/browser authorization with transparent token refresh) for backends that require OAuth. HTTP/SSE only; ignored in stdio mode.
-- **`mcpose`** — `ProxyOptions` gains a required `name` property; the proxy MCP server now advertises `options.name` instead of the generic `'mcpose'`.
+- **`mcpose`** — `ProxyOptions` gains optional `name` and `version` properties that control the MCP server identity advertised in `initialize`. `name` defaults to `'mcpose'`; `version` defaults to the mcpose library version, so set your own proxy's release version when you ship. Omitting `options` entirely stays backward compatible.
+
+### Fixed
+
+- **`mcpose`** — the proxy no longer advertises a hardcoded `'1.1.1'` as its server version; the default now reflects the mcpose library version and is overridable via `ProxyOptions.version`.
 
 ## [2.0.2] - 2026-06-02
 

--- a/README.md
+++ b/README.md
@@ -293,6 +293,8 @@ Middleware arrays, visibility filters (`hiddenTools` / `passThroughTools`), and 
 
 ```ts
 interface ProxyOptions {
+  name?:                 string;
+  version?:              string;
   toolMiddleware?:       ReadonlyArray<ToolMiddleware>;
   resourceMiddleware?:   ReadonlyArray<ResourceMiddleware>;
   listToolsMiddleware?:  ReadonlyArray<ListToolsMiddleware>;
@@ -308,6 +310,9 @@ function createProxyServer(backend: BackendClient, options?: ProxyOptions): Serv
 ```
 
 </details>
+
+`name` and `version` set the MCP server identity returned in `initialize`.
+Both are optional: `name` defaults to `'mcpose'`, and `version` defaults to the mcpose library version, so set your own when you ship a proxy.
 
 `onTelemetry` fires after every tool call with timing, outcome, tool name, and identity.
 Wire it to `@mcpose/otel` or any custom sink.

--- a/packages/core/src/__tests__/backendClient.test.ts
+++ b/packages/core/src/__tests__/backendClient.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { OAuthClientProvider } from '@modelcontextprotocol/sdk/client/auth';
 
 vi.mock('@modelcontextprotocol/sdk/client/streamableHttp.js', () => ({
   StreamableHTTPClientTransport: vi.fn(),
@@ -105,5 +106,67 @@ describe('createBackendClient() URL scheme validation', () => {
     await expect(
       createBackendClient({ url: 'not a url' }),
     ).rejects.toThrow();
+  });
+});
+
+describe('createBackendClient() HTTP transport options', () => {
+  // A recognizable stand-in for an OAuthClientProvider. createBackendClient only
+  // stores the reference, so we assert identity rather than driving a real flow.
+  const stubAuthProvider = {
+    redirectUrl: 'http://localhost:3000/callback',
+  } as unknown as OAuthClientProvider;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  /** Resolves to the options object passed to the last StreamableHTTPClientTransport. */
+  const lastTransportOpts = async () => {
+    const { StreamableHTTPClientTransport } = await import(
+      '@modelcontextprotocol/sdk/client/streamableHttp.js'
+    );
+    return vi.mocked(StreamableHTTPClientTransport).mock.lastCall?.[1] as
+      | {
+          requestInit?: { headers?: Record<string, string> };
+          authProvider?: OAuthClientProvider;
+        }
+      | undefined;
+  };
+
+  it('forwards custom headers to the HTTP transport via requestInit', async () => {
+    const headers = { Authorization: 'Bearer abc', 'X-Trace-Id': '123' };
+    await createBackendClient({ url: 'https://example.com/mcp', headers });
+
+    expect((await lastTransportOpts())?.requestInit?.headers).toEqual(headers);
+  });
+
+  it('forwards an OAuth authProvider to the HTTP transport', async () => {
+    await createBackendClient({
+      url: 'https://example.com/mcp',
+      authProvider: stubAuthProvider,
+    });
+
+    expect((await lastTransportOpts())?.authProvider).toBe(stubAuthProvider);
+  });
+
+  it('forwards headers and authProvider together', async () => {
+    const headers = { Authorization: 'Bearer t' };
+    await createBackendClient({
+      url: 'https://example.com/mcp',
+      headers,
+      authProvider: stubAuthProvider,
+    });
+    const opts = await lastTransportOpts();
+
+    expect(opts?.requestInit?.headers).toEqual(headers);
+    expect(opts?.authProvider).toBe(stubAuthProvider);
+  });
+
+  it('omits requestInit and authProvider when neither is configured', async () => {
+    await createBackendClient({ url: 'https://example.com/mcp' });
+    const opts = await lastTransportOpts();
+
+    expect(opts?.requestInit).toBeUndefined();
+    expect(opts?.authProvider).toBeUndefined();
   });
 });

--- a/packages/core/src/__tests__/core.test.ts
+++ b/packages/core/src/__tests__/core.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 import {
   createProxyServer,
   type ListToolsMiddleware,
@@ -14,6 +16,16 @@ import {
   ToolListChangedNotificationSchema,
   type ServerCapabilities,
 } from '@modelcontextprotocol/sdk/types.js';
+
+/** Independent copy of our own package version, read straight from disk. */
+const pkgVersion = (
+  JSON.parse(
+    readFileSync(
+      fileURLToPath(new URL('../../package.json', import.meta.url)),
+      'utf8',
+    ),
+  ) as { version: string }
+).version;
 
 // ── Test helpers ────────────────────────────────────────────────────────────
 
@@ -644,5 +656,45 @@ describe('createProxyServer() — onTelemetry', () => {
       tool: 'echo',
       outcome: 'error',
     });
+  });
+});
+
+describe('createProxyServer() — server identity', () => {
+  // The MCP SDK stores the advertised server info on a protected `_serverInfo`.
+  const serverInfo = (server: ReturnType<typeof createProxyServer>) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return (server as any)._serverInfo as { name: string; version: string };
+  };
+
+  it('omitting options is allowed and defaults name to "mcpose"', () => {
+    const backend = makeMockBackend();
+    // No options at all: this is the backward-compatible path.
+    const server = createProxyServer(backend);
+
+    expect(serverInfo(server).name).toBe('mcpose');
+  });
+
+  it('honors an explicit name when provided', () => {
+    const backend = makeMockBackend();
+    const server = createProxyServer(backend, { name: 'my-proxy' });
+
+    expect(serverInfo(server).name).toBe('my-proxy');
+  });
+
+  it('defaults version to the mcpose library version when omitted', () => {
+    const backend = makeMockBackend();
+    const server = createProxyServer(backend);
+
+    expect(serverInfo(server).version).toBe(pkgVersion);
+    // Regression guard against the stale hardcoded '1.1.1'.
+    expect(serverInfo(server).version).not.toBe('1.1.1');
+  });
+
+  it('honors an explicit version, independent of the library version', () => {
+    const backend = makeMockBackend();
+    // A developer ships their own proxy version on top of a pinned library.
+    const server = createProxyServer(backend, { version: '9.9.9' });
+
+    expect(serverInfo(server).version).toBe('9.9.9');
   });
 });

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -3,6 +3,7 @@ import { AsyncLocalStorage } from 'node:async_hooks';
 import * as http from 'node:http';
 import * as https from 'node:https';
 import { randomUUID } from 'node:crypto';
+import { createRequire } from 'node:module';
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
@@ -36,6 +37,15 @@ import { createInMemoryEventStore } from './eventStore.js';
 import type { EventStore } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import { rejectionMcpError } from './rejection.js';
 import type { RejectionReason } from './rejection.js';
+
+// Source our own package version once at module load. `createRequire` works under
+// ESM on Node 18+ without the `--experimental-json-modules` flag and avoids the
+// tsconfig and runtime caveats of a static JSON import.
+const readPackageJson = createRequire(import.meta.url);
+const pkg = readPackageJson('../package.json') as { version: string };
+
+/** Name the proxy advertises when `ProxyOptions.name` is omitted. */
+const DEFAULT_PROXY_NAME = 'mcpose';
 
 export type { ProxyContext } from './proxyContext.js';
 
@@ -139,9 +149,17 @@ export interface HttpProxyOptions {
 export interface ProxyOptions {
   /**
    * Human-readable name for this proxy instance.
-   * This is what the new MCP server is called
+   * Defaults to `'mcpose'` when omitted, so leaving out `options` entirely stays
+   * backward compatible.
    */
-  name: string;
+  name?: string;
+
+  /**
+   * Version of this proxy server (yours, not the mcpose library). MCP clients see
+   * it in the `initialize` response. Defaults to the mcpose library version when
+   * omitted; set it to your own release version when you ship your proxy.
+   */
+  version?: string;
 
   /**
    * Tool middleware in response-processing order (first = innermost).
@@ -370,7 +388,7 @@ function registerListChangedForwarders(
  */
 export function createProxyServer(
   backend: BackendClient,
-  options: ProxyOptions,
+  options: ProxyOptions = {},
 ): Server {
   const capabilities = createProxyCapabilities(backend);
   const toolPipeline = pipe(options.toolMiddleware ?? []);
@@ -383,7 +401,10 @@ export function createProxyServer(
   const passThroughResourceSet = new Set(options.passThroughResources ?? []);
 
   const server = new Server(
-    { name: options.name, version: '1.1.1' },
+    {
+      name: options.name ?? DEFAULT_PROXY_NAME,
+      version: options.version ?? pkg.version,
+    },
     { capabilities },
   );
 
@@ -533,7 +554,7 @@ export function createProxyServer(
  */
 export async function startProxy(
   backend: BackendClient,
-  options: ProxyOptions,
+  options: ProxyOptions = {},
 ): Promise<void> {
   const server = createProxyServer(backend, options);
   await server.connect(new StdioServerTransport());
@@ -579,8 +600,8 @@ function applyBodySizeLimit(
  */
 export function startHttpProxy(
   backend: BackendClient,
-  options: ProxyOptions,
-  httpOptions: HttpProxyOptions,
+  options: ProxyOptions = {},
+  httpOptions: HttpProxyOptions = {},
 ): Promise<http.Server> {
   const mcpPath = httpOptions.path ?? '/mcp';
   const port = httpOptions.port ?? 3000;


### PR DESCRIPTION
## Summary

What this change does, in one or two sentences.

## Motivation

Why this change is needed.
Link the issue it closes if there is one (`Closes #123`).

## Changes

-

## Checklist

- [x] `pnpm ts:ci` passes locally.
- [x] `pnpm test` passes locally.
- [x] Tests added or updated for the behavior change.
- [x] Documentation updated (root `README.md` and/or package README, `CONTEXT.md`, ADR).
- [x] No existing audit assertion was weakened.
- [x] If this touches the audit chain, signing, encryption, or `ReplayManifest`, I have read [ADR-0003](../docs/adr/0003-audit-subkeys-derived-from-signing-oracle.md) and [SECURITY.md](../SECURITY.md).

## Notes for review

Anything the reviewer should pay attention to.
