### PR TITLE
version bump to 2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+## [2.1.1] - 2026-07-16
+
+### Changed
+
+- **`mcpose`** — re-release of 2.1.0, which was published to npm then unpublished due to breaking changes.
+- The corrected, non-breaking build is identical to the 2.1.0 in this repository.
+- npm does not allow republishing the same version number, so the corrected build ships as 2.1.1.
+- No functional changes from 2.1.0.
+
 ## [2.1.0] - 2026-07-16
 
 ### Added

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcpose",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "The audit and governance layer for MCP",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

What this change does, in one or two sentences.

## Motivation

Why this change is needed.
Link the issue it closes if there is one (`Closes #123`).

## Changes

-

## Checklist

- [x] `pnpm ts:ci` passes locally.
- [x] `pnpm test` passes locally.
- [x] Tests added or updated for the behavior change.
- [x] Documentation updated (root `README.md` and/or package README, `CONTEXT.md`, ADR).
- [x] No existing audit assertion was weakened.
- [x] If this touches the audit chain, signing, encryption, or `ReplayManifest`, I have read [ADR-0003](../docs/adr/0003-audit-subkeys-derived-from-signing-oracle.md) and [SECURITY.md](../SECURITY.md).

## Notes for review

Anything the reviewer should pay attention to.
