### PR TITLE
test(testing): deflake doctored-hash assertions

### DIFF
--- a/packages/testing/src/__tests__/assertions.test.ts
+++ b/packages/testing/src/__tests__/assertions.test.ts
@@ -85,6 +85,12 @@ describe('assertAuditChainIntegrity', () => {
   });
 });
 
+// Corrupt a hex hash so the result always differs from the input — replacing
+// the last char with a constant would be a no-op 1 in 16 times.
+function corruptHash(hash: string): string {
+  return `${hash.slice(0, -1)}${hash.endsWith('0') ? '1' : '0'}`;
+}
+
 describe('assertReplayManifestValid', () => {
   it('passes for a valid manifest', async () => {
     const { events, manifest } = await collectEvents(5);
@@ -102,7 +108,7 @@ describe('assertReplayManifestValid', () => {
     // Doctor one event AND renumber consistently — keyless chain checks
     // pass, but the root recomputation must catch it.
     const doctored = events.map((e, i) =>
-      i === 1 ? { ...e, chainHash: `${e.chainHash.slice(0, -1)}0` } : e,
+      i === 1 ? { ...e, chainHash: corruptHash(e.chainHash) } : e,
     );
     expect(() => assertReplayManifestValid(doctored, manifest!)).toThrow(/does not recompute/);
   });
@@ -110,7 +116,7 @@ describe('assertReplayManifestValid', () => {
   it('throws when the manifest root was swapped to match doctored events', async () => {
     const { events, manifest } = await collectEvents(3);
     const doctored = events.map((e, i) =>
-      i === 1 ? { ...e, chainHash: `${e.chainHash.slice(0, -1)}0` } : e,
+      i === 1 ? { ...e, chainHash: corruptHash(e.chainHash) } : e,
     );
     // Attacker recomputes a matching root but cannot regenerate the proofs
     // for the untouched leaves.


### PR DESCRIPTION
## Problem

Main-branch CI failed intermittently (e.g. [run 30700842624](https://github.com/amir-gorji/mcpose/actions/runs/30700842624)) on:

`assertReplayManifestValid > throws when the manifest root was swapped to match doctored events`

Both "doctored" tests in `assertions.test.ts` tamper with an event by replacing the last character of its hex `chainHash` with `'0'`.
When the real hash already ends in `'0'` (1-in-16 chance), the tampering is a no-op: the events are untouched, the manifest is genuinely valid, and the assertion correctly does not throw — failing the test.

Reproduced locally at 3/40 runs (~7%), matching the 1/16 odds.

## Fix

Add a `corruptHash` helper that flips the last character to a guaranteed-different value, and use it in both doctored tests.
Test-only change; no production code touched.

## Verification

- Full `@mcpose/testing` suite passes (18/18)
- 40 consecutive runs of the two doctored tests: 0 failures (previously ~7%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)