### PR TITLE
Rewrite the READMEs and record the unreleased changes

### DIFF
--- a/.claude/skills/mcpose-audit-invariants/SKILL.md
+++ b/.claude/skills/mcpose-audit-invariants/SKILL.md
@@ -48,7 +48,7 @@ These two packages produce and verify mcpose's **tamper-evident audit trail**. T
 
 | Assertion | Proves | Does NOT prove |
 |---|---|---|
-| `assertAuditChainIntegrity` | non-empty; positions sequential; `chainHash`es distinct & non-empty | HMAC validity (no key) → not a key-consistent forgery |
+| `assertAuditChainIntegrity` | non-empty; positions sequential; `chainHash`es distinct & non-empty | Authenticity. No HMAC is recomputed, so any self-consistent rewrite passes — and it does not have to be key-consistent, because the forger supplies the hashes. Tail truncation also passes; the manifest's `eventCount` is what catches it |
 | `assertReplayManifestValid` | root recomputes from the events; one proof per event; each proof verifies at its index | the manifest **signature** — `verifyManifestSignature` does that |
 | `assertPiiRedacted` | low/medium: no pattern matches plaintext; high: no plaintext fields present, encrypted payloads present | anything about the CONTENT of high-tier ciphertext |
 | `assertDelegationHonored(event)` | `delegatedFrom` non-empty; each entry has a `sub` | signatures or chain continuity (v3) |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## [Unreleased]
 
+Merged on `main`, not yet published to npm. The current published releases are
+`mcpose@2.1.1`, `@mcpose/audit@2.0.3`, and `@mcpose/testing@2.0.3`.
+
+Note that `packages/audit` declares a peer dependency on `mcpose >= 2.2.0`, so
+this working tree is not installable against the registry until all three are
+released together.
+
+### Changed
+
+- **`@mcpose/audit` 3.0.0 — audit format v2.** BREAKING. Canonical preimages via `canonicalJson`, a signature covering the whole `ReplayManifest` rather than only the Merkle root, domain-separated Merkle leaves and nodes (`mcpose/v2/leaf`, `mcpose/v2/node`), `keyId` no longer derived as `SHA256(secret)`, and per-event ciphertext keys bound to session, position and event with AES-GCM AAD. Chains, manifests, key ids and ciphertexts written under v1 do not verify under v2, and the reverse is also true. There is deliberately no dual-format mode: v1 chains are forgeable by a manifest-holder with a guessable secret, so continuing to attest them would lend the new verifier's credibility to artifacts that do not deserve it. Operators with v1 archives keep verifying them with a pinned `@mcpose/audit` 2.x. See ADR-0004.
+- **`@mcpose/testing` 3.0.0 — strengthened assertions.** BREAKING. `assertAuditChainIntegrity` now throws on an empty chain instead of returning cleanly. `assertReplayManifestValid` recomputes the Merkle root from the events under test and checks that each proof carries its own index. `assertPiiRedacted` structurally checks high-tier events rather than skipping them. `assertDelegationHonored` now takes an `AuditEvent`; it previously took an `Identity[]`, which meant passing an event to it silently passed regardless of the event's contents.
+- **`mcpose` 2.2.0** — audit-visible rejections, pass-through observers.
+
+### Added
+
+- **`@mcpose/audit`** — `verifyAuditChain(events, signingKey)` and `verifyManifestSignature(manifest, signingKey)`, the keyed verifiers. Keyless assertions prove internal consistency; these prove authenticity.
+
 ## [2.1.1] - 2026-07-16
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -459,7 +459,7 @@ npm install @mcpose/audit
 `@mcpose/audit` provides a tamper-evident, compliance-grade audit trail for every tool call. It produces an HMAC-chained log of `AuditEvent` records and a `ReplayManifest` per session: a Merkle-proof document that lets auditors verify what happened without re-executing anything.
 
 Detecting tampering requires the signing secret: `verifyAuditChain(events, signingKey)` recomputes every chain hash, and `verifyManifestSignature(manifest, signingKey)` checks the manifest signature.
-The keyless assertions in [`@mcpose/testing`](#mcposetesting) catch structural tampering (reordering, renumbering, duplication) only.
+The keyless assertions in [`@mcpose/testing`](#mcposetesting) prove internal consistency — reordering, renumbering, duplication, head or middle deletion, and a swapped Merkle root — but not authenticity: a self-consistent forgery with regenerated proofs passes, and tail truncation passes `assertAuditChainIntegrity` (the manifest's `eventCount` catches it). See the [@mcpose/testing README](#mcposetesting) for the limits of each assertion.
 
 `@mcpose/audit` 3.0.0 writes audit format v2, a breaking format change: archives written by a 2.x release verify only with a pinned 2.x.
 See [ADR-0004](./docs/adr/0004-audit-format-v2-canonical-serialization.md) for the canonical-serialization and full-manifest-signature rationale.

--- a/README.md
+++ b/README.md
@@ -6,146 +6,15 @@
 
 [![npm](https://img.shields.io/npm/v/mcpose)](https://www.npmjs.com/package/mcpose)
 [![license](https://img.shields.io/npm/l/mcpose)](./LICENSE)
+[![node](https://img.shields.io/node/v/mcpose)](https://nodejs.org/)
 [![TypeScript](https://img.shields.io/badge/TypeScript-6.x-blue)](https://www.typescriptlang.org/)
 [![CI](https://github.com/amir-gorji/mcpose/actions/workflows/ci.yml/badge.svg)](https://github.com/amir-gorji/mcpose/actions/workflows/ci.yml)
-[![Dependabot](https://img.shields.io/badge/Dependabot-enabled-025E8C?logo=dependabot)](https://github.com/amir-gorji/mcpose/blob/main/.github/dependabot.yml)
 
-The audit and governance layer for MCP.
+**The audit and governance layer for MCP.**
 
-mcpose is a transparent middleware proxy for MCP servers. It intercepts, transforms, and governs tool calls through composable functional middleware, and with `@mcpose/audit`, produces tamper-evident, compliance-grade audit trails that satisfy DORA Article 17 and SR 11-7 requirements.
-
-## Features
-
-- **Transparent proxy**: wrap any upstream MCP server without modifying it.
-- **Composable middleware** with a predictable onion model: each layer runs before *and* after the inner pipeline.
-- **Hide or gate tools and resources** per caller, with a structured `RejectionReason` in every blocked call.
-- **Per-session identity resolution**: resolve a caller once, then stamp the `Identity` on every request in the session.
-- **Compliance-grade audit trails** (DORA Art. 17, SR 11-7) via [`@mcpose/audit`](#mcposeaudit): HMAC-chained events, a Merkle `ReplayManifest`, and AES-256-GCM for high-sensitivity tiers.
-- **HTTP/SSE transport** with mTLS, session limits, and SSE reconnect replay.
-- **Production-minded**: ships ESM with first-class TypeScript types and runs on Node.js 20+.
-
-## When to use mcpose
-
-- You operate MCP servers in a regulated environment (finance, healthcare) and need PII redaction, caller identity, and a tamper-evident audit trail on every tool call.
-- You want to add cross-cutting behavior (logging, redaction, rate limiting, governance) to an MCP server you do not control.
-- You need to hide or gate specific tools and resources per caller, or stamp a resolved identity onto every request.
-
-## Table of Contents
-
-- [Features](#features)
-- [When to use mcpose](#when-to-use-mcpose)
-- [New in 2.0](#new-in-20)
-- [Background](#background)
-- [Concept](#concept)
-- [Packages](#packages)
-- [Install](#install)
-- [Quick Start](#quick-start)
-- [Proxy model](#proxy-model)
-- [Middleware model](#middleware-model)
-- [API Reference](#api-reference)
-- [@mcpose/audit](#mcposeaudit)
-- [@mcpose/testing](#mcposetesting)
-- [Recipe: PII redaction + audit](#recipe-pii-redaction--audit)
-- [Recipe: list_tools rewriting](#recipe-list_tools-rewriting)
-- [Examples](#examples)
-- [Roadmap](#roadmap)
-- [Contributing](#contributing)
-- [License](#license)
-
----
-
-## New in 2.0
-
-- **`@mcpose/audit`**: HMAC-chained audit events, Merkle-proof `ReplayManifest`, AES-256-GCM encryption for high-sensitivity tiers, `createSensitivityResolver`, `createDefaultSigningKeyProvider`
-- **`@mcpose/testing`**: compliance assertion helpers: `assertAuditChainIntegrity`, `assertReplayManifestValid`, `assertPiiRedacted`, `assertDelegationHonored`
-- **Identity resolution**: `resolveIdentity` hook on `HttpProxyOptions`; resolved `Identity` stamped on every `ProxyContext`
-- **Agent delegation chain**: `delegatedFrom?: Identity[]` on `ProxyContext` for A2A handoff recording
-- **mTLS**: pass `tlsOptions` to `startHttpProxy` for mutual TLS
-- **SSE reconnect replay**: built-in in-memory `EventStore` with the `PersistentEventStore` type (an alias of the SDK's `EventStore`) for Redis/Postgres adapters
-- **Session lifecycle hook**: `onSessionClosed` on `HttpProxyOptions`; wire `auditHandle.closeSession` here to flush `ReplayManifest` on session end
-- **Structured rejection reasons**: `RejectionReason` in MCP error `data` field on every blocked call
-
----
-
-## Background
-
-mcpose was extracted from [`financial-elastic-mcp-server`](https://github.com/amir-gorji/financial-elastic-mcp-server), an Elasticsearch MCP server built for financial institutions that needed PII redaction and audit logging on every tool call. Those cross-cutting concerns were originally hardcoded into a single server. mcpose lifts that pattern into a reusable, composable middleware layer that can wrap **any** upstream MCP server.
-
----
-
-## Concept
-
-mcpose is a **transparent proxy** between an LLM client and an upstream MCP server. It mirrors the upstream MCP surface and routes supported calls through middleware. The client sees a normal MCP server; the upstream sees a normal MCP client.
-
----
-
-## Packages
-
-This is a monorepo. Each package publishes independently and has its own README on npm.
-
-| Package | npm | What it does |
-|---|---|---|
-| [`mcpose`](./packages/core/README.md) | [![npm](https://img.shields.io/npm/v/mcpose)](https://www.npmjs.com/package/mcpose) | Proxy core: pipeline, transports, identity, governance. |
-| [`@mcpose/audit`](./packages/audit/README.md) | [![npm](https://img.shields.io/npm/v/@mcpose/audit)](https://www.npmjs.com/package/@mcpose/audit) | Tamper-evident HMAC audit chain + Merkle `ReplayManifest`. |
-| [`@mcpose/testing`](./packages/testing/README.md) | [![npm](https://img.shields.io/npm/v/@mcpose/testing)](https://www.npmjs.com/package/@mcpose/testing) | Runner-agnostic compliance assertions for the audit chain. |
-
----
-
-## Install
-
-**Prerequisites**
-
-- Node.js 20 or newer.
-- `@modelcontextprotocol/sdk` as a peer dependency (installed separately below).
-- For compliance audit trails, also install [`@mcpose/audit`](#mcposeaudit).
-
-```bash
-npm install mcpose
-```
-
-**Peer dependency**: must be installed separately:
-
-```bash
-npm install @modelcontextprotocol/sdk@>=1.0.0
-```
-
-For compliance audit trails:
-
-```bash
-npm install @mcpose/audit
-```
-
----
-
-## Quick Start
-
-```ts
-import { createBackendClient, startProxy } from 'mcpose';
-import type { ToolMiddleware } from 'mcpose';
-
-// 1. Connect to the upstream MCP server (stdio)
-const backend = await createBackendClient({
-  command: 'node',
-  args: ['/path/to/backend-server.mjs'],
-});
-
-// 2. Define middleware
-const loggingMW: ToolMiddleware = async (req, next) => {
-  console.error(`→ ${req.params.name}`);
-  const result = await next(req);
-  console.error(`← ${req.params.name} done`);
-  return result;
-};
-
-// 3. Start the proxy on stdio
-await startProxy(backend, {
-  toolMiddleware: [loggingMW],
-});
-```
-
----
-
-## Proxy model
+mcpose is a transparent middleware proxy for MCP servers.
+It sits between an LLM client and an upstream server, routing every tool, resource, and `list_tools` call through composable middleware you control.
+The client sees a normal MCP server; the upstream sees a normal MCP client; neither has to change.
 
 ```
 ┌──────────────┐        ┌────────────────────────────────┐        ┌────────────────────┐
@@ -157,32 +26,163 @@ await startProxy(backend, {
                         └────────────────────────────────┘
 ```
 
-For each supported tool or resource, mcpose picks one of three routing paths:
+Add [`@mcpose/audit`](./packages/audit/README.md) and every call through that pipeline also becomes a tamper-evident audit record: HMAC-chained, Merkle-anchored, and signed, for evidence that stands up under DORA Article 17 and SR 11-7 review.
 
-| Path | Option | Behavior |
-|---|---|---|
-| **Hidden** | `hiddenTools` / `hiddenResources` | Omitted from list responses; rejected with `TOOL_HIDDEN` / `RESOURCE_HIDDEN` at call time |
-| **Pass-through** | `passThroughTools` / `passThroughResources` | Forwarded raw to upstream; transforming middleware skipped |
-| **Middleware** | everything else | Routed through the full `toolMiddleware` / `resourceMiddleware` pipeline |
+## Table of Contents
 
-For hidden tools, the rejection is thrown inside the middleware pipeline, so middleware such as audit observes the rejected call; the backend is never called.
-A tool listed in both `hiddenTools` and `passThroughTools` stays hidden.
-Pass-through skips transforming middleware only: middleware wrapped in `markPassThroughObserver()` (audit, telemetry) still runs for pass-through tools.
-Prompts are forwarded as-is when the upstream supports prompts.
-
-The proxy preserves core request semantics end to end:
-
-- advertised capabilities are mirrored from the upstream server
-- abort signals are forwarded to upstream tool, resource, and prompt calls
-- upstream progress updates are relayed back to the downstream client
-- list-changed notifications are advertised and fanned out when the upstream supports them
-- `list_tools` responses can be transformed through `listToolsMiddleware` without weakening local `hiddenTools` guarantees (hidden filtering is applied both before and after the middleware)
+- [Features](#features)
+- [Who this is for](#who-this-is-for)
+- [How it compares](#how-it-compares)
+- [Packages](#packages)
+- [Install](#install)
+- [Quick start](#quick-start)
+- [How it works](#how-it-works)
+  - [Routing: hidden, pass-through, middleware](#routing-hidden-pass-through-middleware)
+  - [The middleware onion](#the-middleware-onion)
+  - [Array order: the one surprising rule](#array-order-the-one-surprising-rule)
+  - [What the proxy preserves](#what-the-proxy-preserves)
+- [Guides](#guides)
+  - [PII redaction with audit](#pii-redaction-with-audit)
+  - [Rewriting list_tools](#rewriting-list_tools)
+- [Examples](#examples)
+- [API reference](#api-reference)
+- [Tamper-evidence: what is and is not guaranteed](#tamper-evidence-what-is-and-is-not-guaranteed)
+- [Background](#background)
+- [Roadmap](#roadmap)
+- [Contributing](#contributing)
+- [Security](#security)
+- [License](#license)
 
 ---
 
-## Middleware model
+## Features
 
-Middleware follows the **onion model**: outer layers run code before *and* after inner layers. Each middleware receives the request, a `next` function to invoke the rest of the pipeline, and a normalized `ProxyContext`.
+- **Transparent proxy.** Wrap any upstream MCP server without modifying it, over stdio or HTTP/SSE.
+- **Composable middleware** with a predictable onion model: each layer runs before *and* after the layers inside it.
+- **Hide or gate tools and resources** per caller, with a structured `RejectionReason` on every blocked call instead of an opaque error.
+- **Resolve caller identity once per session**, then read the same `Identity` from every request in that session.
+- **Tamper-evident audit trails** via [`@mcpose/audit`](./packages/audit/README.md): HMAC-chained events, a signed Merkle `ReplayManifest`, and AES-256-GCM encryption for high-sensitivity payloads.
+- **Prove it in CI** with [`@mcpose/testing`](./packages/testing/README.md): runner-agnostic assertions that a trail is intact, redacted, and internally consistent.
+- **Production-minded.** Native ESM, first-class TypeScript types, Node.js 20+, no runtime dependencies beyond the MCP SDK.
+
+## Who this is for
+
+Reach for mcpose when:
+
+- You operate MCP servers in a regulated environment (finance, healthcare) and need PII redaction, caller identity, and a defensible audit trail on every tool call.
+- You need cross-cutting behavior (logging, redaction, rate limiting, governance) on an MCP server you do not own or cannot modify.
+- You need to hide or gate specific tools and resources per caller, and to record what was blocked as well as what ran.
+
+Look elsewhere when:
+
+- You control the single MCP server and need one hook in one place.
+  A request handler in your own server is less machinery than a proxy hop.
+- Your requirement is purely transport-level: TLS termination, IP allowlists, or rate limiting by source address.
+  An HTTP gateway already does that, and mcpose does not replace it.
+- You need the audit trail to re-execute historical calls.
+  A `ReplayManifest` proves *what happened*; session re-execution is v4 work.
+
+## How it compares
+
+mcpose composes with the tools below far more often than it replaces them.
+Versions noted where they matter: mcpose 2.2.0, `@mcpose/audit` 3.0.0.
+
+| If you are currently | It works well when | Where it runs out |
+|---|---|---|
+| **Writing the concern into each MCP server** | You have one server, one team, and the concern is a few lines of logging. | Every new server re-implements redaction and audit. The logic is not independently testable, and it ships on the server's release cycle. |
+| **Putting an HTTP gateway in front of the MCP endpoint** (Envoy, Kong, nginx) | You need TLS, IP policy, or coarse rate limits. Gateways are excellent at this. | A gateway sees a JSON-RPC body, not a tool call. It cannot filter `list_tools`, reject `transfer_funds` for one role, or hash a tool's arguments into an audit chain without parsing MCP itself. |
+| **The MCP SDK's own request handlers** | You own the server and want one hook with zero extra hops. | Handlers are per-server and do not compose. There is no shared onion, no `passThroughTools` escape hatch, and no cross-server identity or audit story. |
+| **A log pipeline (OpenTelemetry, Splunk, ELK)** | You need observability: latency, error rates, volume. mcpose feeds these through `onTelemetry`. | Logs are mutable and unordered by design. They answer "what did we observe"; a regulator asks "prove this record was not altered", which needs the HMAC chain and the signed manifest. |
+
+The honest summary: if you need observability, use a log pipeline, and let mcpose feed it.
+If you need *evidence*, you need the chain and the manifest, and that is what `@mcpose/audit` adds.
+
+## Packages
+
+This is a monorepo.
+Each package publishes independently and carries its own README on npm.
+
+| Package | Version | Stability | What it does |
+|---|---|---|---|
+| [`mcpose`](./packages/core/README.md) | [![npm](https://img.shields.io/npm/v/mcpose)](https://www.npmjs.com/package/mcpose) | Stable | Proxy core: middleware pipeline, stdio and HTTP transports, identity, governance. |
+| [`@mcpose/audit`](./packages/audit/README.md) | [![npm](https://img.shields.io/npm/v/@mcpose/audit)](https://www.npmjs.com/package/@mcpose/audit) | Stable | Tamper-evident HMAC audit chain and signed Merkle `ReplayManifest`. |
+| [`@mcpose/testing`](./packages/testing/README.md) | [![npm](https://img.shields.io/npm/v/@mcpose/testing)](https://www.npmjs.com/package/@mcpose/testing) | Stable | Runner-agnostic compliance assertions over an audit trail. |
+
+`@mcpose/policy`, `@mcpose/fintech-identity`, and `@mcpose/otel` appear in the [roadmap](#roadmap) and do not exist yet.
+
+## Install
+
+**Prerequisites**
+
+- Node.js 20 or newer.
+- `@modelcontextprotocol/sdk` `^1.17.0`, a peer dependency you install yourself.
+
+```bash
+npm install mcpose @modelcontextprotocol/sdk
+```
+
+For tamper-evident audit trails, add the audit package and its test-time assertions:
+
+```bash
+npm install @mcpose/audit
+npm install --save-dev @mcpose/testing
+```
+
+## Quick start
+
+Connect to an upstream over stdio, add one middleware, and serve:
+
+```ts
+import { createBackendClient, startProxy } from 'mcpose';
+import type { ToolMiddleware } from 'mcpose';
+
+// 1. Connect to the upstream MCP server.
+const backend = await createBackendClient({
+  command: 'node',
+  args: ['/path/to/backend-server.mjs'],
+});
+
+// 2. Define middleware: (req, next, ctx) => Promise<result>
+const loggingMW: ToolMiddleware = async (req, next) => {
+  console.error(`→ ${req.params.name}`);
+  const result = await next(req);
+  console.error(`← ${req.params.name} done`);
+  return result;
+};
+
+// 3. Serve the proxy over stdio.
+await startProxy(backend, { toolMiddleware: [loggingMW] });
+```
+
+Point your MCP client at this process instead of the upstream, and every tool call now flows through `loggingMW`.
+
+To serve over HTTP/SSE instead, with per-session identity, mTLS, session limits, and reconnect replay, swap `startProxy` for [`startHttpProxy`](./packages/core/README.md#serving-over-httpsse).
+
+## How it works
+
+### Routing: hidden, pass-through, middleware
+
+For each tool or resource, mcpose picks exactly one of three paths:
+
+| Path | Option | Behavior |
+|---|---|---|
+| **Hidden** | `hiddenTools` / `hiddenResources` | Omitted from list responses, and rejected at call time with `TOOL_HIDDEN` / `RESOURCE_HIDDEN`. |
+| **Pass-through** | `passThroughTools` / `passThroughResources` | Forwarded to the upstream untouched. Transforming middleware is skipped. |
+| **Middleware** | everything else | Routed through the full `toolMiddleware` / `resourceMiddleware` pipeline. |
+
+Three consequences worth knowing up front:
+
+- A hidden tool is rejected *inside* the pipeline, so observing middleware such as audit still records the attempt.
+  The upstream is never called.
+- A tool listed in both `hiddenTools` and `passThroughTools` stays hidden.
+- Pass-through skips *transforming* middleware only.
+  Middleware wrapped in `markPassThroughObserver()` still runs, which is how audit and telemetry keep full coverage.
+  The middleware from `createAuditMiddleware` is wrapped for you.
+
+### The middleware onion
+
+Each middleware receives the request, a `next` function that invokes the rest of the pipeline, and a normalized `ProxyContext`.
+Outer layers run code before *and* after the inner ones:
 
 ```
   request ──►
@@ -200,7 +200,11 @@ Middleware follows the **onion model**: outer layers run code before *and* after
   ◄── response
 ```
 
-**Array order in `ProxyOptions`** uses **response-processing order**: the first element processes the response *first* (innermost layer). To guarantee audit never sees raw PII:
+### Array order: the one surprising rule
+
+Middleware arrays in `ProxyOptions` are in **response-processing order**: the first element processes the response *first*, which makes it the innermost layer.
+This is deliberate, because it is the ordering that makes the safety property obvious.
+To guarantee audit never sees raw PII, put redaction first:
 
 ```ts
 toolMiddleware: [piiMW, auditMW]
@@ -212,484 +216,38 @@ toolMiddleware: [piiMW, auditMW]
 // 5. auditMW exit   → log already-clean data    (processes response last)
 ```
 
-`compose([outerMW, innerMW])` uses the **opposite** (outermost-first) convention: `ProxyOptions` arrays are **not** interchangeable with `compose()` arguments.
+`compose([outerMW, innerMW])` uses the **opposite**, outermost-first convention.
+`ProxyOptions` arrays and `compose()` arguments are not interchangeable.
+See [ADR-0002](./docs/adr/0002-proxy-options-array-response-processing-order.md) for why.
 
-Middleware that must observe every call regardless of pass-through status (audit, telemetry) can be wrapped in `markPassThroughObserver(mw)`.
-A wrapped middleware still runs for tools listed in `passThroughTools`, which skip all other middleware.
-Never use it for middleware that transforms requests or responses: pass-through means "forward upstream as-is".
+### What the proxy preserves
 
-```ts
-import { markPassThroughObserver } from 'mcpose';
+Transparency is a contract, not a slogan.
+End to end, mcpose:
 
-toolMiddleware: [piiMW, markPassThroughObserver(metricsMW)]
-// piiMW is skipped for passThroughTools; metricsMW still sees every call.
-```
+- mirrors the upstream's advertised capabilities,
+- forwards abort signals to upstream tool, resource, and prompt calls,
+- relays upstream progress updates back to the client,
+- advertises and fans out list-changed notifications when the upstream supports them,
+- forwards prompts as-is when the upstream supports prompts,
+- applies `hiddenTools` filtering both before *and* after `listToolsMiddleware`, so middleware cannot re-add a hidden tool.
 
-The middleware returned by `createAuditMiddleware` in `@mcpose/audit` is already wrapped, so pass-through tools stay audited without extra setup.
+## Guides
 
----
+### PII redaction with audit
 
-## API Reference
-
-> The canonical API reference for each package lives in its own README: [`packages/core`](./packages/core/README.md), [`@mcpose/audit`](./packages/audit/README.md), and [`@mcpose/testing`](./packages/testing/README.md).
-> The full type signatures are reproduced below, with the dense reference collapsed for scannability.
-
-### `ProxyContext` · `Middleware<Req, Res>` · `ToolMiddleware` · `ResourceMiddleware` · `ListToolsMiddleware` · `compose()` · `markPassThroughObserver()` · `createProxyContext()`
-
-The per-request `ProxyContext`, the `Identity` shape, the middleware type aliases, and the `hasToolContent` type guard.
-
-<details>
-<summary>Show type definitions</summary>
+The origin use case: a financial-grade MCP server where every response must be scrubbed of PII before it reaches the LLM *or* the audit log.
 
 ```ts
-interface ProxyContext {
-  requestId: string;
-  transport: 'stdio' | 'http';
-  sessionId?: string;
-  headers?: Readonly<Record<string, string>>;
-  signal?: AbortSignal;
-  /** Resolved caller identity. Present when resolveIdentity is configured. */
-  identity?: Identity;
-  /** Agent delegation chain: populated from A2A handoff headers. */
-  delegatedFrom?: Identity[];
-  /** Reserved for v3 policy engine. */
-  policy?: never;
-}
-
-interface Identity {
-  sub: string;
-  type: 'human' | 'agent' | 'service';
-  displayName?: string;
-  roles: string[];
-  claims: Record<string, unknown>;
-  resolvedAt: string;  // ISO 8601
-  source: 'jwt' | 'mtls' | 'apikey' | 'custom';
-}
-
-function createProxyContext(overrides?: Partial<ProxyContext>): ProxyContext;
-
-type Middleware<Req, Res> = (
-  req: Req,
-  next: (req: Req) => Promise<Res>,
-  context: ProxyContext,
-) => Promise<Res>;
-
-type ToolMiddleware     = Middleware<CallToolRequest, CompatibilityCallToolResult>;
-type ResourceMiddleware = Middleware<ReadResourceRequest, ReadResourceResult>;
-type ListToolsMiddleware = Middleware<ListToolsRequest, ListToolsResult>;
-
-// Type guard: narrows CompatibilityCallToolResult to CallToolResult
-function hasToolContent(r: CompatibilityCallToolResult): r is CallToolResult;
-
-// Wraps a middleware so it still runs for passThroughTools (returns a new
-// middleware; the input is not mutated). Use for observers, never transformers.
-function markPassThroughObserver<Req, Res>(mw: Middleware<Req, Res>): Middleware<Req, Res>;
-```
-
-</details>
-
----
-
-### `BackendConfig` · `createBackendClient()`
-
-```ts
-interface BackendConfig {
-  command?: string;   // Executable to spawn for stdio transport (e.g., "node")
-  args?:    string[]; // Arguments for the spawned process
-  url?:     string;   // HTTP endpoint of a running MCP server (takes precedence over stdio)
-}
-
-async function createBackendClient(config: BackendConfig): Promise<BackendClient>;
-```
-
----
-
-### `ProxyOptions` · `startProxy()` · `createProxyServer()`
-
-Middleware arrays, visibility filters (`hiddenTools` / `passThroughTools`), and the telemetry hook.
-
-<details>
-<summary>Show the <code>ProxyOptions</code> interface and entry-point signatures</summary>
-
-```ts
-interface ProxyOptions {
-  name?:                 string;
-  version?:              string;
-  toolMiddleware?:       ReadonlyArray<ToolMiddleware>;
-  resourceMiddleware?:   ReadonlyArray<ResourceMiddleware>;
-  listToolsMiddleware?:  ReadonlyArray<ListToolsMiddleware>;
-  passThroughTools?:     ReadonlyArray<string>;
-  passThroughResources?: ReadonlyArray<string>;
-  hiddenTools?:          ReadonlyArray<string>;
-  hiddenResources?:      ReadonlyArray<string>;
-  onTelemetry?:          (event: TelemetryEvent) => void;
-}
-
-async function startProxy(backend: BackendClient, options?: ProxyOptions): Promise<void>;
-function createProxyServer(backend: BackendClient, options?: ProxyOptions): Server;
-```
-
-</details>
-
-`name` and `version` set the MCP server identity returned in `initialize`.
-Both are optional: `name` defaults to `'mcpose'`, and `version` defaults to the mcpose library version, so set your own when you ship a proxy.
-
-`onTelemetry` fires after every tool call with timing, outcome, tool name, and identity.
-Wire it to any custom sink; an OpenTelemetry adapter (`@mcpose/otel`) is planned for v3.
-Results with `isError: true` are reported as outcome `'error'`, and a throwing sink is logged but never fails the tool call.
-
-`createProxyServer` throws if the backend is not connected, so a mis-wired proxy fails at startup instead of on the first call.
-
----
-
-### `HttpProxyOptions` · `startHttpProxy()`
-
-The HTTP/SSE entry point: port/host/path, body and session limits, per-session identity resolution, mTLS, and the SSE reconnect replay store.
-
-<details>
-<summary>Show the <code>HttpProxyOptions</code> interface and <code>startHttpProxy()</code> signature</summary>
-
-```ts
-interface HttpProxyOptions {
-  port?: number;         // Default: 3000
-  host?: string;         // Default: all interfaces
-  path?: string;         // Default: '/mcp'
-  onRequest?: (req: http.IncomingMessage, res: http.ServerResponse) => boolean | Promise<boolean>;
-  onError?: (err: unknown) => void;
-  maxBodyBytes?: number; // Default: 4 MB; returns 413 on excess
-  maxSessions?: number;  // Excess requests return 503
-  sessionTtlMs?: number; // Sessions auto-close after this duration
-  /** Resolves caller identity once per session. Errors abort the session with 401. */
-  resolveIdentity?: (req: http.IncomingMessage) => Identity | Promise<Identity>;
-  /** Re-validates an existing session on every routed request. Return false (or throw) for a 401. */
-  validateSession?: (
-    req: http.IncomingMessage,
-    session: { sessionId: string; identity?: Identity },
-  ) => boolean | Promise<boolean>;
-  /** mTLS: pass Node's https.ServerOptions (key, cert, ca, requestCert, rejectUnauthorized). */
-  tlsOptions?: https.ServerOptions;
-  /** SSE reconnect replay store. Defaults to in-memory. Pass null to disable.
-   *  PersistentEventStore is an alias of the SDK's EventStore type. */
-  eventStore?: PersistentEventStore | null;
-  /** Called when a session closes: client DELETE, TTL expiry, or server shutdown. */
-  onSessionClosed?: (sessionId: string) => void;
-  /** Hosts allowed in the Host header when DNS-rebinding protection is on. Forwarded to the SDK transport. */
-  allowedHosts?: string[];
-  /** Origins allowed in the Origin header. Forwarded to the SDK transport. */
-  allowedOrigins?: string[];
-  /** Enables the SDK transport's Host/Origin checks. Recommended for localhost proxies. */
-  enableDnsRebindingProtection?: boolean;
-}
-
-function startHttpProxy(
-  backend: BackendClient,
-  options?: ProxyOptions,
-  httpOptions?: HttpProxyOptions,
-): Promise<http.Server>;
-```
-
-</details>
-
-```ts
-import { createBackendClient, startHttpProxy } from 'mcpose';
-
-const backend = await createBackendClient({ url: 'http://upstream-mcp-server/mcp' });
-const server = await startHttpProxy(backend, { toolMiddleware: [loggingMW] }, { port: 8080 });
-```
-
-On shutdown, active proxy sessions are closed before the underlying `http.Server` finishes closing.
-`onSessionClosed` fires on every session-end path: client DELETE, TTL expiry, and server shutdown, so audit manifests flush in all three cases.
-
-Only an `initialize` POST can create a session; a session-less GET or DELETE returns 400.
-Use `validateSession` to bind a session to its original credential (for example, re-check the bearer token) so a leaked `mcp-session-id` alone cannot take over a session.
-
-Credential-bearing headers (`authorization`, `proxy-authorization`, `cookie`, `set-cookie`, `x-api-key`) are stripped from `ProxyContext.headers` before middleware (and through it, audit logs) can see them; `resolveIdentity` reads the raw `http.IncomingMessage`, so it still sees them.
-
-503 (session limit) and 413 (body limit) responses carry a JSON body with `error.data.rejectionReason` set to `SESSION_LIMIT` / `BODY_LIMIT`.
-
-SSE reconnect replay is scoped per stream: the in-memory store replays only events from the reconnecting stream, and an unknown or already-evicted `Last-Event-ID` replays nothing.
-
----
-
-### `RejectionReason` · `rejectionMcpError()`
-
-Every blocked call embeds a `RejectionReason` in the MCP error `data` field.
-The top-level error code is unchanged, so existing clients that only inspect the code are unaffected.
-Audit middleware and agents can inspect `error.data.rejectionReason` for programmatic handling.
-
-`rejectionMcpError(reason, code, message)` builds an `McpError` with the reason embedded in `error.data`, so custom middleware can reject calls in the same structured shape the proxy uses.
-
-<details>
-<summary>Show the <code>RejectionReason</code> union</summary>
-
-```ts
-type RejectionReason =
-  | 'TOOL_HIDDEN'           // tool exists but is hidden from this caller
-  | 'RESOURCE_HIDDEN'       // resource exists but is hidden from this caller
-  | 'POLICY_DENIED'         // v3: RBAC policy blocked the call
-  | 'IDENTITY_UNRESOLVED'   // v3: identity could not be established
-  | 'CONSENT_MISSING'       // v3: GDPR/CCPA consent gate blocked the call
-  | 'SENSITIVITY_BLOCKED'   // v3: data sensitivity policy blocked the call
-  | 'DELEGATION_INVALID'    // v3: agent delegation chain is invalid or expired
-  | 'BUDGET_EXCEEDED'       // v3: cost budget for this session/user exceeded
-  | 'SESSION_LIMIT'         // max concurrent sessions reached (HTTP 503)
-  | 'BODY_LIMIT';           // request body exceeded maxBodyBytes (HTTP 413)
-```
-
-</details>
-
----
-
-### `mcpose/testing`
-
-```ts
-import { createMockBackendClient, runToolMiddleware } from 'mcpose/testing';
-```
-
-`createMockBackendClient()` returns an in-memory backend stub with capability lookup and notification hooks. It works with both `createProxyServer()` and `startHttpProxy()` tests.
-
----
-
-## `@mcpose/audit`
-
-```bash
-npm install @mcpose/audit
-```
-
-`@mcpose/audit` provides a tamper-evident, compliance-grade audit trail for every tool call. It produces an HMAC-chained log of `AuditEvent` records and a `ReplayManifest` per session: a Merkle-proof document that lets auditors verify what happened without re-executing anything.
-
-Detecting tampering requires the signing secret: `verifyAuditChain(events, signingKey)` recomputes every chain hash, and `verifyManifestSignature(manifest, signingKey)` checks the manifest signature.
-The keyless assertions in [`@mcpose/testing`](#mcposetesting) prove internal consistency — reordering, renumbering, duplication, head or middle deletion, and a swapped Merkle root — but not authenticity: a self-consistent forgery with regenerated proofs passes, and tail truncation passes `assertAuditChainIntegrity` (the manifest's `eventCount` catches it). See the [@mcpose/testing README](#mcposetesting) for the limits of each assertion.
-
-`@mcpose/audit` 3.0.0 writes audit format v2, a breaking format change: archives written by a 2.x release verify only with a pinned 2.x.
-See [ADR-0004](./docs/adr/0004-audit-format-v2-canonical-serialization.md) for the canonical-serialization and full-manifest-signature rationale.
-
-The audit layer never throws into the tool-call path: its own failures (event serialization, a throwing `onEvent` sink) are reported to the `onAuditError` hook instead.
-
-### Sensitivity tiers
-
-Every audit event is classified by a `SensitivityTier`:
-
-| Tier | Stored fields |
-|---|---|
-| `'low'` | `inputRaw`, `outputRaw` (plaintext) |
-| `'medium'` | `inputRaw`, `outputRaw` (PII already redacted upstream) |
-| `'high'` | `inputEncrypted`, `outputEncrypted` (AES-256-GCM, per-event key) |
-
-Unknown tools always resolve to `'high'`.
-
-### Quick start
-
-```ts
-import { createAuditMiddleware, createDefaultSigningKeyProvider, createSensitivityResolver } from '@mcpose/audit';
-import { startHttpProxy } from 'mcpose';
-
-// Supplied by your application:
-//   backend: an mcpose BackendClient (see Quick Start above)
-//   auditLog: your durable sink for audit events
-//   manifestStore: your durable sink for replay manifests
-//   piiMW: an upstream redaction middleware
-//   extractJwt: your resolveIdentity function
-
-const signingKey = createDefaultSigningKeyProvider(process.env.AUDIT_SECRET!);
-
-const sensitivityResolver = createSensitivityResolver({
-  get_balance:    'low',
-  search_trades:  'medium',
-  transfer_funds: 'high',
-});
-
-const auditHandle = createAuditMiddleware({
-  signingKey,
-  sensitivityResolver,
-  onEvent: (event) => auditLog.append(event),
-  onManifest: (manifest) => manifestStore.save(manifest),
-});
-
-const server = await startHttpProxy(backend, {
-  toolMiddleware: [piiMW, auditHandle.middleware],
-}, {
-  resolveIdentity: extractJwt,
-  onSessionClosed: (sessionId) => auditHandle.closeSession(sessionId),
-});
-```
-
-### `createSensitivityResolver(map, override?)`
-
-```ts
-const resolver = createSensitivityResolver(
-  { get_balance: 'low', search: 'medium' },
-  // Optional override fn: takes precedence over the static map.
-  // The 4th argument is the map's resolution (already defaulted to 'high'
-  // for unknown tools), so the override can fall back to it.
-  (tool, identity, args, mapTier) =>
-    identity.roles.includes('admin') ? 'low' : mapTier,
-);
-```
-
-The override function type is exported as `SensitivityOverrideFn`.
-Unknown tools not in the map always resolve to `'high'` unless the override fn returns otherwise.
-
-### `createDefaultSigningKeyProvider(secret)`
-
-```ts
-const signingKey = createDefaultSigningKeyProvider('your-secret-or-buffer');
-// { algorithm: 'HMAC-SHA256', keyId: '<sha256-of-secret>', sign(data) }
-```
-
-HMAC-SHA256 in-process signing. For production, implement `SigningKeyProvider` against your KMS.
-
-### `createAuditMiddleware(options)`
-
-```ts
-interface AuditOptions {
-  signingKey: SigningKeyProvider;
-  sensitivityResolver: SensitivityResolverFn;
-  onEvent: (event: AuditEvent) => void | Promise<void>;
-  /**
-   * Called with the finished ReplayManifest when closeSession() is invoked.
-   *
-   * Why this exists: ToolMiddleware is a pure per-request function with no
-   * lifecycle hooks. Sessions are owned by the HTTP transport, not by
-   * middleware. The host signals session end via closeSession(); onManifest
-   * is the push-based delivery mechanism for the resulting manifest.
-   */
-  onManifest?: (manifest: ReplayManifest) => void | Promise<void>;
-  /** Record events for rejected calls (hidden tools etc.). Default: true. */
-  includeRejections?: boolean;
-  /**
-   * Called when the audit layer itself fails (event serialization, a
-   * throwing onEvent sink). The audit layer NEVER throws into the
-   * tool-call path. Default: console.error.
-   */
-  onAuditError?: (
-    err: unknown,
-    info: { tool: string; requestId: string; sessionId?: string },
-  ) => void;
-}
-
-interface AuditMiddlewareHandle {
-  middleware: ToolMiddleware;
-  closeSession(sessionId: string): Promise<ReplayManifest | undefined>;
-}
-```
-
-`closeSession` returns `undefined` if the session had no events or is unknown. Wire it to `HttpProxyOptions.onSessionClosed`.
-The returned `middleware` is already marked as a pass-through observer, so tools listed in `passThroughTools` stay audited.
-
-### `AuditEvent` schema
-
-A discriminated union on `sensitivityTier`.
-The base record every event shares (hashes, chain link, outcome, identity).
-
-<details>
-<summary>Show the <code>AuditEvent</code> schema</summary>
-
-```ts
-// Discriminated union on sensitivityTier
-type AuditEvent = LowAuditEvent | MediumAuditEvent | HighAuditEvent;
-
-interface AuditEventBase {
-  id: string;                    // = ProxyContext.requestId
-  startedAt: string;             // ISO timestamp captured before the upstream call started
-  endedAt: string;               // ISO timestamp captured after the upstream call settled
-  sessionId?: string;
-  identity: Identity;
-  delegatedFrom?: Identity[];
-  tool: string;
-  duration_ms: number;
-  outcome: 'success' | 'rejected' | 'error';
-  /** Present when outcome is 'rejected' (from the MCP error's data field). */
-  rejectionReason?: RejectionReason;
-  /** Present when outcome is 'error': what the upstream call threw. */
-  error?: { name: string; message: string };
-  inputHash: string;             // SHA-256
-  outputHash: string;
-  chainHash: string;             // HMAC(entry || prevChainHash)
-  replayManifestPosition: number;
-}
-```
-
-</details>
-
-### `ReplayManifest`
-
-Produced at session close.
-Covers all audit events with a Merkle root and individual proofs, signed by the `SigningKeyProvider`.
-The signature covers the canonical serialization of the entire manifest (every field, domain-separated), not just the Merkle root; verify it with `verifyManifestSignature(manifest, signingKey)`.
-Any third party can verify a single event without access to the full log.
-
-<details>
-<summary>Show the <code>ReplayManifest</code> interface</summary>
-
-```ts
-interface ReplayManifest {
-  sessionId: string;
-  identity: Identity;
-  startedAt: string;
-  closedAt: string;
-  eventCount: number;
-  merkleRoot: string;
-  merkleProofs: MerkleProof[];
-  signedBy: string;   // keyId
-  signature: string;  // HMAC over the canonical serialization of the ENTIRE manifest
-}
-```
-
-</details>
-
-### Verifiers and canonical serialization
-
-`@mcpose/audit` exports the keyed verifiers and the canonical serialization helpers they build on:
-
-| Export | Purpose |
-|---|---|
-| `verifyAuditChain(events, signingKey)` | Recomputes every event's `chainHash` with the chain key; reports the first bad index. An empty event list is invalid. |
-| `verifyManifestSignature(manifest, signingKey)` | Constant-time check of the full-manifest signature. |
-| `canonicalJson(value)` | Strict canonical JSON (keys sorted at every depth); the hash/signature preimage format. |
-| `stableStringify(value)` | Total, key-order-independent serialization used for `inputHash`/`outputHash`. |
-
----
-
-## `@mcpose/testing`
-
-```bash
-npm install --save-dev @mcpose/testing
-```
-
-Compliance assertion helpers for use in test suites:
-
-```ts
-import {
-  assertAuditChainIntegrity,
-  assertReplayManifestValid,
-  assertPiiRedacted,
-  assertDelegationHonored,
-} from '@mcpose/testing';
-```
-
-| Function | What it checks |
-|---|---|
-| `assertAuditChainIntegrity(events)` | Sequential positions, non-empty and distinct chain hashes; throws on an empty chain (a log truncated to zero events must not pass) |
-| `assertReplayManifestValid(events, manifest)` | Event count matches; the Merkle root recomputes from the events under test; one proof per event, each verifying at its own index |
-| `assertPiiRedacted(event, patterns)` | Low/medium: no pattern matches the plaintext fields. High: the event is structurally encrypted (no plaintext `inputRaw`/`outputRaw` present, encrypted payloads present) |
-| `assertDelegationHonored(event)` | The event's `delegatedFrom` chain is non-empty and every entry has a `sub` |
-
-These assertions are deliberately keyless: the signing secret is not available to tests.
-They prove the artifact is internally consistent: they catch reordering, renumbering, duplication, head or middle deletion, and a swapped Merkle root.
-They do not prove it is authentic. A forger who rewrites every event and regenerates the root and proofs produces a document these assertions accept, and does not need the signing secret to do it. Deleting from the tail also leaves a valid prefix, so `assertAuditChainIntegrity` alone accepts it; `manifest.eventCount` is what catches that.
-For keyed verification, use `verifyAuditChain(events, signingKey)` and `verifyManifestSignature(manifest, signingKey)` from `@mcpose/audit`.
-
----
-
-## Recipe: PII redaction + audit
-
-The origin use case for mcpose: a financial-grade MCP server where every Elasticsearch tool response must be scrubbed of PII before it reaches the LLM or the audit log.
-
-```ts
-import { hasToolContent } from 'mcpose';
+import { hasToolContent, startHttpProxy } from 'mcpose';
 import type { ToolMiddleware } from 'mcpose';
-import { createAuditMiddleware, createDefaultSigningKeyProvider, createSensitivityResolver } from '@mcpose/audit';
+import {
+  createAuditMiddleware,
+  createDefaultSigningKeyProvider,
+  createSensitivityResolver,
+} from '@mcpose/audit';
+
+// Supplied by your application: backend, auditLog, manifestStore, extractJwt.
 
 function createPiiMiddleware(patterns: RegExp[]): ToolMiddleware {
   return async (req, next) => {
@@ -713,29 +271,33 @@ const auditHandle = createAuditMiddleware({
   onManifest: (m) => manifestStore.save(m),
 });
 
-await startHttpProxy(backend, {
-  toolMiddleware: [
-    createPiiMiddleware([/\b\d{9}\b/g, /[A-Z]{2}\d{6}/g]), // PII first
-    auditHandle.middleware,                                   // audit sees clean data
-  ],
-}, {
-  resolveIdentity: extractJwt,
-  onSessionClosed: (id) => auditHandle.closeSession(id),
-});
+await startHttpProxy(
+  backend,
+  {
+    toolMiddleware: [
+      createPiiMiddleware([/\b\d{9}\b/g, /[A-Z]{2}\d{6}/g]), // redaction runs first
+      auditHandle.middleware,                                // so audit records clean data
+    ],
+  },
+  {
+    resolveIdentity: extractJwt,
+    onSessionClosed: (id) => auditHandle.closeSession(id),
+  },
+);
 ```
 
-PII is redacted *before* the audit layer ever sees the response; no raw PII reaches a log.
+Because of the [array order rule](#array-order-the-one-surprising-rule), PII is redacted before the audit layer ever sees the response, so no raw PII reaches a log.
 
-> **Reference implementation:** [`elastic-pii-proxy`](https://github.com/amir-gorji/elastic-pii-proxy) is a production example of this pattern: an Elasticsearch MCP proxy that uses mcpose with PII redaction and `@mcpose/audit` to serve financial data safely to LLM agents.
+> **Reference implementation:** [`elastic-pii-proxy`](https://github.com/amir-gorji/elastic-pii-proxy) runs this pattern in production, proxying Elasticsearch to LLM agents over mcpose with redaction and `@mcpose/audit`.
 
----
+### Rewriting list_tools
 
-## Recipe: list_tools rewriting
+Reshape the tool catalog the client sees without touching the upstream:
 
 ```ts
 import type { ListToolsMiddleware } from 'mcpose';
 
-const enrichDescriptions: ListToolsMiddleware = async (req, next, context) => {
+const enrichDescriptions: ListToolsMiddleware = async (req, next) => {
   const result = await next(req);
   return {
     ...result,
@@ -748,69 +310,115 @@ const enrichDescriptions: ListToolsMiddleware = async (req, next, context) => {
 };
 ```
 
-`hiddenTools` remains authoritative even if a `listToolsMiddleware` tries to re-add a hidden tool.
-
----
+`hiddenTools` stays authoritative: filtering is applied after this middleware too, so it cannot re-add a hidden tool.
 
 ## Examples
 
-Runnable, well-commented examples live in [`examples/`](./examples/).
+Runnable, commented examples live in [`examples/`](./examples/).
 
-| File | What it shows |
-|---|---|
-| [`pii-redaction-audit.ts`](./examples/pii-redaction-audit.ts) | The canonical mcpose pattern: PII redaction composed with audit middleware over HTTP/SSE, with per-session identity resolution. |
-| [`governance-proxy.ts`](./examples/governance-proxy.ts) | Governance features: `hiddenTools`, `passThroughTools`, and `onTelemetry`. Self-contained, uses `createMockBackendClient` so no upstream server is needed. |
-| [`oauth-upstream-client.ts`](./examples/oauth-upstream-client.ts) | Connecting to an OAuth-protected remote MCP server from Node: dynamic client registration, PKCE, browser authorization, and persisted tokens with automatic refresh. |
+| Example | What it shows | Needs an upstream? |
+|---|---|---|
+| [`governance-proxy.ts`](./examples/governance-proxy.ts) | `hiddenTools`, `passThroughTools`, and `onTelemetry`, against a mock backend. | No |
+| [`pii-redaction-audit.ts`](./examples/pii-redaction-audit.ts) | The canonical pattern: redaction composed with audit over HTTP/SSE, with per-session identity. | Yes |
+| [`oauth-upstream-client.ts`](./examples/oauth-upstream-client.ts) | Connecting to an OAuth-protected upstream: dynamic registration, PKCE, persisted tokens with refresh. | Yes, OAuth-capable |
 
-The examples resolve the workspace packages directly, so they run against your checkout:
+Start with `governance-proxy`, which is self-contained:
 
 ```bash
-# From the repository root:
 pnpm install
-pnpm --filter mcpose-examples governance-proxy        # governance (self-contained, no upstream needed)
-pnpm --filter mcpose-examples pii-redaction-audit     # PII redaction + audit (needs an upstream MCP server)
-pnpm --filter mcpose-examples oauth-upstream-client   # OAuth against a remote MCP server
+pnpm --filter mcpose-examples governance-proxy
 ```
 
-The comments in each file walk through the setup step by step and mark the values you need to supply: upstream endpoint, audit secret, identity resolver, and durable sinks.
+See the [examples README](./examples/README.md) for the full run matrix.
 
----
+## API reference
+
+Each package's README is the canonical reference for its own exports, and each is self-contained:
+
+| Package | Reference covers |
+|---|---|
+| [`mcpose`](./packages/core/README.md#api-surface) | `createBackendClient`, `startProxy`, `startHttpProxy`, `createProxyServer`, `compose`, `markPassThroughObserver`, `rejectionMcpError`, `createProxyContext`, `createInMemoryEventStore`, `hasToolContent`, and the `ProxyContext` / `Identity` / `ProxyOptions` / `HttpProxyOptions` / `RejectionReason` types. |
+| [`@mcpose/audit`](./packages/audit/README.md#api-surface) | `createAuditMiddleware`, `createSensitivityResolver`, `createDefaultSigningKeyProvider`, `verifyAuditChain`, `verifyManifestSignature`, the Merkle helpers, the canonical serializers, and the `AuditEvent` / `ReplayManifest` / `AuditOptions` schemas. |
+| [`@mcpose/testing`](./packages/testing/README.md#api) | `assertAuditChainIntegrity`, `assertReplayManifestValid`, `assertPiiRedacted`, `assertDelegationHonored`, each with what it does and does not prove. |
+
+Test helpers for the proxy itself (`createMockBackendClient`, `runToolMiddleware`) ship in the core package under the `mcpose/testing` subpath.
+That is a different thing from the `@mcpose/testing` package, which asserts audit chains.
+See [the core README](./packages/core/README.md#test-helpers-mcposetesting) for the distinction.
+
+Vocabulary used across all of these is defined once in [`CONTEXT.md`](./CONTEXT.md).
+
+## Tamper-evidence: what is and is not guaranteed
+
+The value of an audit trail is what it can prove to someone who does not trust you, so the boundaries matter more than the feature list.
+
+**With the signing secret**, `verifyAuditChain(events, signingKey)` recomputes every chain hash and `verifyManifestSignature(manifest, signingKey)` checks the manifest signature.
+Together these detect insertion, deletion, reordering, and modification anywhere in the trail.
+The signature covers the canonical serialization of the *entire* manifest, not just the Merkle root, so no field is silently swappable.
+
+**Without the signing secret**, the assertions in `@mcpose/testing` prove internal consistency only.
+They catch reordering, renumbering, duplication, head or middle deletion, and a swapped Merkle root.
+They do **not** prove authenticity: a forger who rewrites every event and regenerates the root and proofs produces a document they accept, and needs no secret to do it.
+Tail truncation also leaves a valid prefix, so `assertAuditChainIntegrity` alone accepts it; the manifest's `eventCount` is what catches that.
+
+Two more boundaries worth stating plainly:
+
+- The chain binds payloads through `inputHash` / `outputHash`, and does not cover `sensitivityTier`.
+  Post-hoc tampering with the tier alone is not chain-detectable.
+- Chaining requires a session id.
+  Over stdio there is no session, so every event carries position 0 and no manifest is produced.
+
+The reasoning behind the key hierarchy is in [ADR-0003](./docs/adr/0003-audit-subkeys-derived-from-signing-oracle.md), and the canonical-serialization format in [ADR-0004](./docs/adr/0004-audit-format-v2-canonical-serialization.md).
+`@mcpose/audit` 3.0.0 writes audit format v2, a breaking change: archives written by a 2.x release verify only under a pinned 2.x.
+
+## Background
+
+mcpose was extracted from [`financial-elastic-mcp-server`](https://github.com/amir-gorji/financial-elastic-mcp-server), an Elasticsearch MCP server built for financial institutions that needed PII redaction and audit logging on every tool call.
+Those concerns started life hardcoded into one server.
+mcpose lifts the pattern into a reusable middleware layer that can wrap **any** upstream MCP server.
+
+Release history lives in [`CHANGELOG.md`](./CHANGELOG.md).
 
 ## Roadmap
 
+Shipped:
+
 - [x] Composable middleware: `startProxy()`, `startHttpProxy()`, `createProxyServer()`
 - [x] Streamable HTTP transport with stateful sessions and SSE reconnect replay
-- [x] Identity resolution: `resolveIdentity` hook, `Identity` on `ProxyContext`
-- [x] mTLS support: `tlsOptions` on `HttpProxyOptions`
-- [x] `@mcpose/audit`: HMAC chain, Merkle proofs, `ReplayManifest`, sensitivity tiers
-- [x] `@mcpose/testing`: compliance assertion helpers
-- [ ] `@mcpose/policy`: RBAC policy engine (v3)
-- [ ] `@mcpose/fintech-identity`: OIDC → financial identity profile (v3)
-- [ ] `@mcpose/otel`: OpenTelemetry spans adapter (v3)
-- [ ] Persistent EventStore adapters: Redis, Postgres (v3)
-- [ ] GDPR/CCPA consent middleware + cryptographic erasure (v3)
+- [x] Identity resolution: the `resolveIdentity` hook, with `Identity` on every `ProxyContext`
+- [x] mTLS through `tlsOptions` on `HttpProxyOptions`
+- [x] `@mcpose/audit`: HMAC chain, Merkle proofs, signed `ReplayManifest`, sensitivity tiers
+- [x] `@mcpose/testing`: compliance assertions
 
----
+Planned for v3:
+
+- [ ] `@mcpose/policy`: RBAC policy engine
+- [ ] `@mcpose/fintech-identity`: OIDC to financial identity profile
+- [ ] `@mcpose/otel`: OpenTelemetry span adapter for `onTelemetry`
+- [ ] Persistent `EventStore` adapters for Redis and Postgres
+- [ ] A delegation header spec, so core can populate `delegatedFrom` itself
+- [ ] GDPR/CCPA consent middleware with cryptographic erasure
+
+Session re-execution from a `ReplayManifest` is v4.
 
 ## Contributing
 
 Contributions are welcome.
-See [`CONTRIBUTING.md`](./CONTRIBUTING.md) for the development setup, the common `pnpm` commands, and the project conventions around `CONTEXT.md` and the ADRs.
+[`CONTRIBUTING.md`](./CONTRIBUTING.md) covers the development setup, the common `pnpm` commands, and the conventions around `CONTEXT.md` and the ADRs.
 
-A few load-bearing rules:
+Three rules carry more weight than the rest:
 
-- The `@mcpose/audit` tamper-evidence invariants must never silently break.
-  Read [ADR-0003](./docs/adr/0003-audit-subkeys-derived-from-signing-oracle.md) and [ADR-0004](./docs/adr/0004-audit-format-v2-canonical-serialization.md) before touching the chain, signing, encryption, or `ReplayManifest`.
+- Read [ADR-0003](./docs/adr/0003-audit-subkeys-derived-from-signing-oracle.md) and [ADR-0004](./docs/adr/0004-audit-format-v2-canonical-serialization.md) before touching the chain, key derivation, encryption, or `ReplayManifest`.
+  These invariants fail silently: a change can compile, pass tests, and still void the guarantee.
 - Run `pnpm ts:ci` and `pnpm test` before opening a pull request.
-- Do not weaken an existing audit assertion to make a test pass.
+- Never weaken an existing audit assertion to make a test pass.
 
 By participating you agree to uphold the [Code of Conduct](./CODE_OF_CONDUCT.md).
 
-To report a security vulnerability, follow [`SECURITY.md`](./SECURITY.md) and report it privately.
-Do not open a public issue for security reports.
+## Security
 
----
+Report vulnerabilities privately by following [`SECURITY.md`](./SECURITY.md).
+Do not open a public issue for a security report.
 
 ## License
 
-MIT
+MIT © Amir Gorji

--- a/README.md
+++ b/README.md
@@ -676,7 +676,8 @@ import {
 | `assertDelegationHonored(event)` | The event's `delegatedFrom` chain is non-empty and every entry has a `sub` |
 
 These assertions are deliberately keyless: the signing secret is not available to tests.
-They catch structural tampering (reordering, renumbering, duplication, a swapped Merkle root), but not a forgery rewritten consistently by a key-holder, and they do not verify the manifest signature.
+They prove the artifact is internally consistent: they catch reordering, renumbering, duplication, head or middle deletion, and a swapped Merkle root.
+They do not prove it is authentic. A forger who rewrites every event and regenerates the root and proofs produces a document these assertions accept, and does not need the signing secret to do it. Deleting from the tail also leaves a valid prefix, so `assertAuditChainIntegrity` alone accepts it; `manifest.eventCount` is what catches that.
 For keyed verification, use `verifyAuditChain(events, signingKey)` and `verifyManifestSignature(manifest, signingKey)` from `@mcpose/audit`.
 
 ---

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,36 +1,47 @@
 # mcpose examples
 
-Runnable examples demonstrating the core mcpose patterns.
-Each example is a self-contained TypeScript file.
+Runnable, self-contained examples of the core mcpose patterns.
+Each is one TypeScript file with a header comment stating its goal, architecture, prerequisites, and run command.
 
-## Running an example
+Every example resolves `mcpose` and `@mcpose/audit` from the workspace, so it always exercises the local source, and `pnpm turbo ts:ci` type-checks all of them in CI.
 
-From the repository root, install dependencies and run with `tsx`:
+## Start here
+
+`governance-proxy` is the one to run first: it uses `createMockBackendClient`, so it needs no upstream server and no secrets.
 
 ```bash
-# Install workspace dependencies (repo root)
+# From the repository root:
 pnpm install
-
-# Run an example (from the repo root)
-pnpm --filter mcpose-examples governance-proxy        # governance (self-contained, no upstream needed)
-pnpm --filter mcpose-examples pii-redaction-audit     # PII redaction + audit (needs an upstream MCP server)
-pnpm --filter mcpose-examples oauth-upstream-client   # OAuth-authenticated upstream backend
+pnpm --filter mcpose-examples governance-proxy
 ```
 
-The examples resolve `mcpose` and `@mcpose/audit` from the workspace, so they always exercise the local source, and `pnpm turbo ts:ci` type-checks them in CI.
+## The examples
 
-Each example expects a few things supplied by your application: an upstream MCP server endpoint, an identity resolver, and durable sinks for audit events and manifests.
-The `pii-redaction-audit.ts` example needs an upstream MCP server; `governance-proxy.ts` uses `createMockBackendClient` and runs with zero external dependencies.
-The comments in each file mark these clearly.
+| Example | Type | What it shows | Prerequisites |
+|---|---|---|---|
+| [`governance-proxy.ts`](./governance-proxy.ts) | Feature demo | `hiddenTools`, `passThroughTools`, and `onTelemetry`. Covers all three routing paths in one file, because they are conceptually one feature. | None. Fully self-contained. |
+| [`pii-redaction-audit.ts`](./pii-redaction-audit.ts) | Canonical use case | The pattern mcpose was built for: PII redaction composed with audit middleware over HTTP/SSE, with per-session identity resolution. | An upstream MCP server, an audit secret, an identity resolver, and durable sinks. |
+| [`oauth-upstream-client.ts`](./oauth-upstream-client.ts) | Integration recipe | Connecting to an OAuth-protected upstream via `BackendConfig.authProvider`: dynamic client registration, PKCE, browser authorization, and persisted tokens with automatic refresh. | An OAuth-capable upstream MCP server. |
 
-## Examples
+Run any of them from the repository root:
 
-| File | What it shows |
-|---|---|
-| [`pii-redaction-audit.ts`](./pii-redaction-audit.ts) | The canonical mcpose pattern: PII redaction middleware composed with audit middleware, served over HTTP/SSE with per-session identity resolution. This is the origin use case for mcpose. Requires an upstream MCP server. |
-| [`governance-proxy.ts`](./governance-proxy.ts) | Governance features: `hiddenTools`, `passThroughTools`, and `onTelemetry`. Uses `createMockBackendClient` so it runs with zero external dependencies. No upstream server needed. |
-| [`oauth-upstream-client.ts`](./oauth-upstream-client.ts) | Connecting the proxy to an OAuth-protected upstream via `BackendConfig.authProvider`. Requires an OAuth-capable upstream MCP server. |
+```bash
+pnpm --filter mcpose-examples governance-proxy        # no upstream needed
+pnpm --filter mcpose-examples pii-redaction-audit     # needs an upstream MCP server
+pnpm --filter mcpose-examples oauth-upstream-client   # needs an OAuth-capable upstream
+```
+
+## What you have to supply
+
+The two examples that talk to a real upstream expect values only you can provide: an upstream endpoint, an audit secret, an identity resolver, and durable sinks for audit events and manifests.
+Each is marked with a loud comment at the point of use, so nothing is left to guess.
+
+None of the examples hardcode a real secret.
+`pii-redaction-audit.ts` reads `AUDIT_SECRET` and `UPSTREAM_URL` from the environment, falling back to obvious development placeholders so the file runs unconfigured.
+Set `AUDIT_SECRET` to a high-entropy value (32+ random bytes) before the pattern means anything: the derived `keyId` is published in every replay manifest, so a guessable secret is offline-attackable.
 
 ## Reference implementation
 
-[`elastic-pii-proxy`](https://github.com/amir-gorji/elastic-pii-proxy) is a production example of the PII redaction + audit pattern: an Elasticsearch MCP proxy that uses mcpose to serve financial data safely to LLM agents.
+[`elastic-pii-proxy`](https://github.com/amir-gorji/elastic-pii-proxy) runs the PII redaction and audit pattern in production: an Elasticsearch MCP proxy that uses mcpose to serve financial data safely to LLM agents.
+
+It is a reference implementation rather than an example, so read it once the files here make sense, not before.

--- a/packages/audit/README.md
+++ b/packages/audit/README.md
@@ -2,39 +2,53 @@
 
 [![npm](https://img.shields.io/npm/v/@mcpose/audit)](https://www.npmjs.com/package/@mcpose/audit)
 [![license](https://img.shields.io/npm/l/@mcpose/audit)](https://github.com/amir-gorji/mcpose/blob/main/LICENSE)
+[![node](https://img.shields.io/node/v/@mcpose/audit)](https://nodejs.org/)
 [![TypeScript](https://img.shields.io/badge/TypeScript-6.x-blue)](https://www.typescriptlang.org/)
 [![CI](https://github.com/amir-gorji/mcpose/actions/workflows/ci.yml/badge.svg)](https://github.com/amir-gorji/mcpose/actions/workflows/ci.yml)
 
 **Tamper-evident audit middleware for [mcpose](https://www.npmjs.com/package/mcpose).**
 
-`@mcpose/audit` turns every tool call flowing through an mcpose proxy into a tamper-evident **audit event**: HMAC-chained to its predecessor, hashed, and (for high-sensitivity calls) encrypted at rest. When a **session** closes, it emits a signed **replay manifest** with a Merkle root and per-event proofs, so any third party can verify that a single event happened without access to the full log.
-
-## Features
-
-- **HMAC-chained audit events**: every event is cryptographically linked to its predecessor over a canonical serialization; a secret-holder can detect insertion, deletion, or reordering with `verifyAuditChain`.
-- **Signed ReplayManifest**: the signature covers the entire manifest (session, identity, event count, Merkle root, and proofs); per-event Merkle proofs let third parties verify a single event without access to the full log.
-- **Full coverage**: rejected calls (hidden tools) and `passThroughTools` are audited too — the middleware is a pass-through observer.
-- **Sensitivity-tiered storage**: classify tools as low, medium, or high sensitivity; high-tier payloads are AES-256-GCM encrypted at rest with per-event keys; unknown or invalid tiers fail closed to `high`.
-- **Subkey derivation through the signing oracle**: chain keys and encryption keys derive from the signing secret through domain-separated derivation, never from the public key id (see [ADR-0003](https://github.com/amir-gorji/mcpose/blob/main/docs/adr/0003-audit-subkeys-derived-from-signing-oracle.md) and [ADR-0004](https://github.com/amir-gorji/mcpose/blob/main/docs/adr/0004-audit-format-v2-canonical-serialization.md)).
-- **Never blocks the call path**: audit failures (a throwing sink, unserializable payloads) are routed to `onAuditError`; the tool call always completes with its real result or error.
-- **Durable-sink integration**: push audit events and replay manifests to your own storage via `onEvent` and `onManifest` callbacks. No lock-in to a specific database or log system.
-
-## When to reach for it
-
-You operate an MCP server in a regulated environment (e.g. financial services) and need to prove, after the fact, exactly which tool calls happened, by whom, in what order, with cryptographic evidence that the record has not been altered, inserted into, or truncated.
+`@mcpose/audit` turns every tool call flowing through an mcpose proxy into a tamper-evident **audit event**: HMAC-chained to its predecessor, hashed, and, for high-sensitivity calls, encrypted at rest.
+When a **session** closes it emits a signed **replay manifest** with a Merkle root and per-event proofs, so a third party can verify that a single event happened without access to the full log.
 
 ## Table of Contents
 
-- [Features](#features)
 - [When to reach for it](#when-to-reach-for-it)
+- [Features](#features)
 - [Install](#install)
 - [Quick start](#quick-start)
 - [How it works](#how-it-works)
 - [Security model](#security-model)
+  - [What the chain covers](#what-the-chain-covers)
+  - [What it does not cover](#what-it-does-not-cover)
+  - [Key hierarchy](#key-hierarchy)
 - [API surface](#api-surface)
+  - [`createAuditMiddleware(options)`](#createauditmiddlewareoptions)
+  - [`createSensitivityResolver(map, override?)`](#createsensitivityresolvermap-override)
+  - [`createDefaultSigningKeyProvider(secret)`](#createdefaultsigningkeyprovidersecret)
+  - [`AuditEvent`](#auditevent)
+  - [`ReplayManifest`](#replaymanifest)
+  - [Verification](#verification)
 - [Testing](#testing)
 - [Documentation](#documentation)
 - [License](#license)
+
+## When to reach for it
+
+You operate an MCP server in a regulated environment and need to prove, after the fact, exactly which tool calls happened, by whom, and in what order, with cryptographic evidence that the record has not been altered, inserted into, or truncated.
+
+If what you actually need is observability (latency, error rates, call volume), reach for mcpose core's `onTelemetry` hook and your existing log pipeline instead.
+This package exists for the harder problem: a record that stays credible when someone disputes it.
+
+## Features
+
+- **HMAC-chained audit events.** Every event is cryptographically linked to its predecessor over a canonical serialization, so a secret-holder can detect insertion, deletion, or reordering with `verifyAuditChain`.
+- **Signed ReplayManifest.** The signature covers the *entire* manifest (session, identity, timestamps, event count, Merkle root, and every proof), not just the root, so no field is silently swappable.
+- **Full coverage.** Rejected calls (hidden tools) and `passThroughTools` are audited too, because the middleware is registered as a pass-through observer.
+- **Sensitivity-tiered storage.** Classify tools as low, medium, or high; high-tier payloads are AES-256-GCM encrypted at rest with per-event keys. Unknown or invalid tiers fail closed to `high`.
+- **Subkeys derived through the signing oracle.** Chain and encryption keys derive from the signing secret with domain separation, never from the public key id ([ADR-0003](https://github.com/amir-gorji/mcpose/blob/main/docs/adr/0003-audit-subkeys-derived-from-signing-oracle.md)).
+- **Never blocks the call path.** Audit failures (a throwing sink, unserializable payloads) are routed to `onAuditError`; the tool call always completes with its real result or error.
+- **No storage lock-in.** Events and manifests are pushed to your own sinks through `onEvent` and `onManifest`.
 
 ## Install
 
@@ -42,9 +56,13 @@ You operate an MCP server in a regulated environment (e.g. financial services) a
 npm install @mcpose/audit mcpose
 ```
 
-`mcpose` (>= 2.2.0) is a peer dependency. Requires Node.js 20+ (uses `node:crypto`).
+Requires Node.js 20+ (uses `node:crypto`).
+`mcpose` (`>=2.2.0 <4`) is a peer dependency.
 
-> **Format note:** version 3.0.0 writes the v2 audit format (`mcpose/v2/*` domain labels). Chains and manifests written by 2.x do not verify under 3.x; keep a pinned 2.x for verifying old archives. See [ADR-0004](https://github.com/amir-gorji/mcpose/blob/main/docs/adr/0004-audit-format-v2-canonical-serialization.md).
+> **Format note:** version 3.0.0 writes the **v2 audit format** (`mcpose/v2/*` domain labels).
+> Chains and manifests written by a 2.x release do not verify under 3.x.
+> Keep a pinned 2.x to verify old archives.
+> See [ADR-0004](https://github.com/amir-gorji/mcpose/blob/main/docs/adr/0004-audit-format-v2-canonical-serialization.md).
 
 ## Quick start
 
@@ -57,13 +75,13 @@ import {
 import { startHttpProxy } from 'mcpose';
 
 // Supplied by your application:
-//   backend: an mcpose BackendClient (see `mcpose` docs)
+//   backend: an mcpose BackendClient (see the `mcpose` docs)
 //   auditLog: your durable sink for audit events
 //   manifestStore: your durable sink for replay manifests
 //   piiMW: an upstream redaction middleware
 //   extractJwt: your resolveIdentity function
 
-// The signing secret never leaves the process; all subkeys derive from it.
+// The signing secret never leaves the process; every subkey derives from it.
 const signingKey = createDefaultSigningKeyProvider(process.env.AUDIT_SECRET!);
 
 // Map tools to a sensitivity tier. Unknown tools resolve to 'high'.
@@ -82,6 +100,7 @@ const auditHandle = createAuditMiddleware({
 
 await startHttpProxy(
   backend,
+  // Redaction first, so audit only ever records clean data.
   { toolMiddleware: [piiMW, auditHandle.middleware] },
   {
     resolveIdentity: extractJwt,
@@ -91,58 +110,248 @@ await startHttpProxy(
 );
 ```
 
+Two wiring details decide whether this actually works:
+
+- **Middleware order.** `ProxyOptions` arrays are in response-processing order, so `[piiMW, auditHandle.middleware]` redacts *before* it audits. Reversing it logs raw PII.
+- **`onSessionClosed`.** Without it, no manifest is ever produced, because nothing tells the audit layer a session ended.
+
 ## How it works
 
-- **Audit event**: a record of one tool call: `identity`, `tool`, `outcome`, input/output hashes, and a `chainHash` linking it to the previous event. `AuditEvent` is a discriminated union on `sensitivityTier`.
-- **Sensitivity tier** (`low` | `medium` | `high`): decides whether the event stores plaintext (`inputRaw`/`outputRaw`) or AES-256-GCM ciphertext (`inputEncrypted`/`outputEncrypted`). Unknown tools default to `high`.
-- **Replay manifest**: produced at session close: a Merkle root over every event's `chainHash`, individual `MerkleProof`s, and a signature over the root. Proves *what happened*; it does not re-execute calls.
+- **Audit event**: the record of one tool call: `identity`, `tool`, `outcome`, input and output hashes, and a `chainHash` linking it to its predecessor.
+  `AuditEvent` is a discriminated union on `sensitivityTier`.
+- **Sensitivity tier** (`low` | `medium` | `high`): decides whether the event stores plaintext (`inputRaw` / `outputRaw`) or AES-256-GCM ciphertext (`inputEncrypted` / `outputEncrypted`).
+- **Replay manifest**: produced at session close. A Merkle root over every event's `chainHash`, one proof per event, and a signature over the whole document.
+  It proves *what happened*; it does not re-execute anything.
+
+**Sessions are required for chaining.**
+Chaining needs `ProxyContext.sessionId`, which only HTTP transport provides.
+Over stdio there is no session, so every event carries position 0 with an empty previous hash, and no manifest is produced.
+This is intentional, not a gap to work around.
 
 ## Security model
 
-The append-only HMAC chain makes insertion, deletion, or reordering of events detectable **by a holder of the signing secret** (use `verifyAuditChain`); without the secret, the keyless assertions in `@mcpose/testing` prove internal consistency — reordering, renumbering, duplication, head or middle deletion, and a swapped Merkle root — but not authenticity (see the [`@mcpose/testing` README](https://www.npmjs.com/package/@mcpose/testing) for the limits). The signed manifest anchors the whole session; high-tier payloads are encrypted at rest with AAD binding each ciphertext to its event and direction.
+The append-only HMAC chain makes insertion, deletion, and reordering detectable **by a holder of the signing secret**.
+The signed manifest anchors the whole session, and high-tier payloads are encrypted at rest with AAD binding each ciphertext to its own event and direction.
 
-> **The signing secret is the root of all of it.** The per-entry **chain key** and the per-event AES **encryption root** are derived from the secret *through* the `SigningKeyProvider.sign()` oracle with domain separation, never from the public **key id**. The key id (`ReplayManifest.signedBy`) is a public identifier only; **never use it as key material**, and never hand-roll the chain or encryption keys. See **[ADR-0003](https://github.com/amir-gorji/mcpose/blob/main/docs/adr/0003-audit-subkeys-derived-from-signing-oracle.md)** for the reasoning and the attack it closes.
+### What the chain covers
 
-For production, implement `SigningKeyProvider` against your KMS rather than holding the secret in process. `createDefaultSigningKeyProvider` is HMAC-SHA256 in-process signing, suitable for development and single-trust deployments. The secret must be high-entropy (32+ random bytes) — `keyId` is published in every manifest, so a guessable passphrase is offline-attackable.
+Each link is `HMAC(chainKey, canonicalJson({ domain, prevChainHash, event }))` over this field set:
+
+`id`, `startedAt`, `endedAt`, `sessionId?`, `delegatedFrom?`, `identity`, `tool`, `duration_ms`, `outcome`, `rejectionReason?`, `error?`, `inputHash`, `outputHash`, `replayManifestPosition`.
+
+Serialization is canonical (keys sorted at every depth), so key insertion order is not load-bearing and an independently written verifier reproduces the same hash.
+The **field set** is what matters, and it is defined once in the source and shared by producer and verifier.
+
+### What it does not cover
+
+Stating the boundaries precisely is the point of an audit trail, so:
+
+- **`sensitivityTier` is not in the preimage.** Post-hoc tampering with the tier alone is not chain-detectable.
+- **Payloads are bound only by hash.** `inputHash` / `outputHash` commit to the payload; the raw and encrypted bodies themselves are not in the preimage.
+- **The keyless assertions in `@mcpose/testing` do not prove authenticity.** They prove internal consistency, catching reordering, renumbering, duplication, head or middle deletion, and a swapped Merkle root. A forger who rewrites every event and regenerates the root and proofs produces a document they accept, and does not need the signing secret to do it, because the forger supplies the hashes. See [that package's README](https://www.npmjs.com/package/@mcpose/testing) for the per-assertion limits.
+- **Tail truncation leaves a valid prefix.** Head and middle deletion renumber everything after them and are caught; truncating the tail is not, so `assertAuditChainIntegrity` accepts it on its own. The manifest's `eventCount` is what catches it.
+
+### Key hierarchy
+
+> **The signing secret is the root of all of it.**
+> The per-entry **chain key** and the per-event AES **encryption root** derive from the secret *through* the `SigningKeyProvider.sign()` oracle with domain separation, never from the public **key id**.
+> `ReplayManifest.signedBy` is a public identifier only.
+> **Never use it as key material**, and never hand-roll the chain or encryption keys.
+> See **[ADR-0003](https://github.com/amir-gorji/mcpose/blob/main/docs/adr/0003-audit-subkeys-derived-from-signing-oracle.md)** for the attack this closes.
+
+The secret must be high-entropy (32+ random bytes).
+`keyId` is published in every manifest, so a guessable passphrase is offline-attackable.
+
+For production, implement `SigningKeyProvider` against your KMS rather than holding the secret in process.
+`createDefaultSigningKeyProvider` is in-process HMAC-SHA256 signing, suitable for development and single-trust deployments.
 
 ## API surface
 
 | Export | Purpose |
 |---|---|
 | `createAuditMiddleware(options)` | Returns `{ middleware, closeSession }`. Add `middleware` to the pipeline; call `closeSession(sessionId)` to emit the manifest. |
-| `createSensitivityResolver(map, override?)` | Build a `SensitivityResolverFn`; `override` receives the map's resolution as its fourth argument and can fall back to it. Unknown or invalid tiers resolve to `high`. |
+| `createSensitivityResolver(map, override?)` | Build a `SensitivityResolverFn`. Unknown or invalid tiers resolve to `high`. |
 | `createDefaultSigningKeyProvider(secret)` | In-process HMAC-SHA256 `SigningKeyProvider`. |
-| `verifyAuditChain(events, signingKey)` | KEYED chain verification: recomputes every chainHash; reports the first tampered index. |
-| `verifyManifestSignature(manifest, signingKey)` | Recomputes the full-manifest signature; constant-time comparison. |
+| `verifyAuditChain(events, signingKey)` | **Keyed** chain verification: recomputes every `chainHash` and reports the first tampered index. An empty event list is invalid. |
+| `verifyManifestSignature(manifest, signingKey)` | **Keyed** check of the full-manifest signature, in constant time. |
 | `computeMerkleRoot` · `computeMerkleProof` · `verifyMerkleProof` | Low-level Merkle helpers for independent verification. |
-| `canonicalJson` · `stableStringify` | The canonical serializations the format is defined over (for independent verifiers). |
+| `canonicalJson` · `stableStringify` | The canonical serializations the format is defined over, exported so third parties can write their own verifier. |
 
 **Key types:** `AuditEvent` (`LowAuditEvent` \| `MediumAuditEvent` \| `HighAuditEvent`), `AuditEventBase`, `SensitivityTier`, `SensitivityResolverFn`, `SensitivityOverrideFn`, `SigningKeyProvider`, `AuditOptions`, `AuditMiddlewareHandle`, `ReplayManifest`, `MerkleProof`, `ChainVerification`.
 
-### `AuditOptions`
+### `createAuditMiddleware(options)`
+
+<details>
+<summary>Show <code>AuditOptions</code> and <code>AuditMiddlewareHandle</code></summary>
 
 ```ts
 interface AuditOptions {
   signingKey: SigningKeyProvider;
   sensitivityResolver: SensitivityResolverFn;
   onEvent: (event: AuditEvent) => void | Promise<void>;
+  /**
+   * Called with the finished ReplayManifest when closeSession() is invoked.
+   *
+   * Why this exists: ToolMiddleware is a pure per-request function with no
+   * lifecycle hooks, and sessions are owned by the HTTP transport rather
+   * than by middleware. The host signals session end via closeSession();
+   * onManifest is the push-based delivery mechanism for the result.
+   */
   onManifest?: (manifest: ReplayManifest) => void | Promise<void>;
-  includeRejections?: boolean; // default: true — audit rejected calls too
-  onAuditError?: (err, info) => void; // default: console.error — audit never throws into the call path
+  /** Record events for rejected calls (hidden tools etc.). Default: true. */
+  includeRejections?: boolean;
+  /**
+   * Called when the audit layer itself fails (event serialization, a
+   * throwing onEvent sink). The audit layer NEVER throws into the
+   * tool-call path. Default: console.error.
+   */
+  onAuditError?: (
+    err: unknown,
+    info: { tool: string; requestId: string; sessionId?: string },
+  ) => void;
+}
+
+interface AuditMiddlewareHandle {
+  middleware: ToolMiddleware;
+  closeSession(sessionId: string): Promise<ReplayManifest | undefined>;
 }
 ```
 
-`closeSession(sessionId)` returns `undefined` if the session had no events or is unknown. Wire it to `HttpProxyOptions.onSessionClosed`.
+</details>
+
+`closeSession` returns `undefined` if the session had no events or is unknown; wire it to `HttpProxyOptions.onSessionClosed`.
+The returned `middleware` is already marked as a pass-through observer, so tools in `passThroughTools` stay audited with no extra setup.
+
+The handle is a pair rather than a bare middleware for a structural reason: middleware is per-request and has no lifecycle, so session end has to be signalled from outside.
+
+### `createSensitivityResolver(map, override?)`
+
+```ts
+const resolver = createSensitivityResolver(
+  { get_balance: 'low', search: 'medium' },
+  // Optional override, which takes precedence over the static map.
+  // The 4th argument is the map's own resolution (already defaulted to
+  // 'high' for unknown tools), so the override can fall back to it.
+  (tool, identity, args, mapTier) =>
+    identity.roles.includes('admin') ? 'low' : mapTier,
+);
+```
+
+The override function type is exported as `SensitivityOverrideFn`.
+
+**This resolver fails closed on purpose.**
+Tool names are attacker-controlled, so lookup uses `Object.hasOwn` (a tool named `toString` must not inherit a prototype value and bypass the default), tier values are validated, and anything unknown or malformed resolves to `'high'`.
+Only an explicit `'low'` or `'medium'` results in plaintext storage.
+
+### `createDefaultSigningKeyProvider(secret)`
+
+```ts
+const signingKey = createDefaultSigningKeyProvider(process.env.AUDIT_SECRET!);
+// → { algorithm: 'HMAC-SHA256', keyId, sign(data) }
+```
+
+`keyId` is derived as a domain-separated HMAC of the secret, not a bare hash of it.
+That distinction matters: `keyId` is published in every manifest, and a bare digest would let anyone holding a manifest brute-force a low-entropy secret offline.
+It remains **public** either way, so it is never key material.
+
+### `AuditEvent`
+
+A discriminated union on `sensitivityTier`, sharing one base record.
+
+| Tier | Stored fields |
+|---|---|
+| `'low'` | `inputRaw`, `outputRaw` (plaintext) |
+| `'medium'` | `inputRaw`, `outputRaw` (plaintext; PII already redacted upstream) |
+| `'high'` | `inputEncrypted`, `outputEncrypted` (AES-256-GCM, per-event key) |
+
+<details>
+<summary>Show the <code>AuditEventBase</code> schema</summary>
+
+```ts
+type AuditEvent = LowAuditEvent | MediumAuditEvent | HighAuditEvent;
+
+interface AuditEventBase {
+  id: string;                    // = ProxyContext.requestId
+  startedAt: string;             // ISO timestamp, captured before the upstream call
+  endedAt: string;               // ISO timestamp, captured after it settled
+  sessionId?: string;
+  identity: Identity;
+  delegatedFrom?: Identity[];
+  tool: string;
+  duration_ms: number;
+  outcome: 'success' | 'rejected' | 'error';
+  /** Present when outcome is 'rejected' (from the MCP error's data field). */
+  rejectionReason?: RejectionReason;
+  /** Present when outcome is 'error': what the upstream call threw. */
+  error?: { name: string; message: string };
+  inputHash: string;             // SHA-256 over a stable serialization
+  outputHash: string;
+  chainHash: string;             // HMAC over the canonical preimage
+  replayManifestPosition: number;
+}
+```
+
+</details>
+
+A missing `ctx.identity` degrades to an anonymous identity rather than failing the call.
+
+### `ReplayManifest`
+
+Produced at session close, covering every audit event with a Merkle root and individual proofs, signed by the `SigningKeyProvider`.
+Any third party can verify a single event without access to the full log.
+
+<details>
+<summary>Show the <code>ReplayManifest</code> interface</summary>
+
+```ts
+interface ReplayManifest {
+  sessionId: string;
+  identity: Identity;
+  startedAt: string;
+  closedAt: string;
+  eventCount: number;
+  merkleRoot: string;
+  merkleProofs: MerkleProof[];
+  signedBy: string;   // public keyId
+  signature: string;  // HMAC over the canonical serialization of the ENTIRE manifest
+}
+```
+
+</details>
+
+Merkle leaves and internal nodes are hashed under **different** domain labels, so an internal node can never be presented as a leaf.
+Odd layers duplicate the last node, and `closeSession` never signs an empty manifest.
+
+### Verification
+
+```ts
+import { verifyAuditChain, verifyManifestSignature } from '@mcpose/audit';
+
+const result = await verifyAuditChain(events, signingKey);
+if (!result.valid) throw new Error(`Chain broken at index ${result.firstInvalidIndex}`);
+
+if (!(await verifyManifestSignature(manifest, signingKey))) {
+  throw new Error('Manifest signature does not verify');
+}
+```
+
+These are the **keyed** verifiers and the only ones that prove authenticity.
+Use them wherever the signing secret is available: a verification job, a compliance export, an incident investigation.
+In test suites, where the secret usually is not available, use [`@mcpose/testing`](#testing) and read its stated limits.
 
 ## Testing
 
-Verify chains and manifests in your test suite with [`@mcpose/testing`](https://www.npmjs.com/package/@mcpose/testing): `assertAuditChainIntegrity`, `assertReplayManifestValid`, `assertPiiRedacted`.
+Verify chains and manifests in your test suite with [`@mcpose/testing`](https://www.npmjs.com/package/@mcpose/testing): `assertAuditChainIntegrity`, `assertReplayManifestValid`, `assertPiiRedacted`, and `assertDelegationHonored`.
+
+Those assertions are deliberately keyless and prove internal consistency, not authenticity.
+Pair them with `verifyAuditChain` and `verifyManifestSignature` anywhere the secret *is* available.
 
 ## Documentation
 
-- [Full README & API reference](https://github.com/amir-gorji/mcpose#mcposeaudit)
+- [Project README](https://github.com/amir-gorji/mcpose#readme): concepts, comparison, and guides
 - [ADR-0003: audit subkeys derived from the signing oracle](https://github.com/amir-gorji/mcpose/blob/main/docs/adr/0003-audit-subkeys-derived-from-signing-oracle.md)
-- [CONTEXT.md](https://github.com/amir-gorji/mcpose/blob/main/CONTEXT.md): canonical domain glossary
+- [ADR-0004: audit format v2 and canonical serialization](https://github.com/amir-gorji/mcpose/blob/main/docs/adr/0004-audit-format-v2-canonical-serialization.md)
+- [`CONTEXT.md`](https://github.com/amir-gorji/mcpose/blob/main/CONTEXT.md): the canonical domain glossary
 
 ## License
 

--- a/packages/audit/README.md
+++ b/packages/audit/README.md
@@ -99,7 +99,7 @@ await startHttpProxy(
 
 ## Security model
 
-The append-only HMAC chain makes insertion, deletion, or reordering of events detectable **by a holder of the signing secret** (use `verifyAuditChain`); without the secret, the keyless assertions in `@mcpose/testing` catch only structural tampering. The signed manifest anchors the whole session; high-tier payloads are encrypted at rest with AAD binding each ciphertext to its event and direction.
+The append-only HMAC chain makes insertion, deletion, or reordering of events detectable **by a holder of the signing secret** (use `verifyAuditChain`); without the secret, the keyless assertions in `@mcpose/testing` prove internal consistency — reordering, renumbering, duplication, head or middle deletion, and a swapped Merkle root — but not authenticity (see the [`@mcpose/testing` README](https://www.npmjs.com/package/@mcpose/testing) for the limits). The signed manifest anchors the whole session; high-tier payloads are encrypted at rest with AAD binding each ciphertext to its event and direction.
 
 > **The signing secret is the root of all of it.** The per-entry **chain key** and the per-event AES **encryption root** are derived from the secret *through* the `SigningKeyProvider.sign()` oracle with domain separation, never from the public **key id**. The key id (`ReplayManifest.signedBy`) is a public identifier only; **never use it as key material**, and never hand-roll the chain or encryption keys. See **[ADR-0003](https://github.com/amir-gorji/mcpose/blob/main/docs/adr/0003-audit-subkeys-derived-from-signing-oracle.md)** for the reasoning and the attack it closes.
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -2,30 +2,17 @@
 
 [![npm](https://img.shields.io/npm/v/mcpose)](https://www.npmjs.com/package/mcpose)
 [![license](https://img.shields.io/npm/l/mcpose)](https://github.com/amir-gorji/mcpose/blob/main/LICENSE)
+[![node](https://img.shields.io/node/v/mcpose)](https://nodejs.org/)
 [![TypeScript](https://img.shields.io/badge/TypeScript-6.x-blue)](https://www.typescriptlang.org/)
 [![CI](https://github.com/amir-gorji/mcpose/actions/workflows/ci.yml/badge.svg)](https://github.com/amir-gorji/mcpose/actions/workflows/ci.yml)
 
 **The composable middleware proxy for MCP.**
 
-mcpose sits between a **client** (an LLM or agent) and an **upstream** MCP server, forwarding every tool, resource, and `list_tools` call through a **pipeline** of composable middleware. It is a transparent proxy: the client talks to mcpose exactly as it would talk to the upstream, while you intercept, transform, hide, or govern calls in between, without touching the upstream server.
+mcpose sits between a **client** (an LLM or agent) and an **upstream** MCP server, forwarding every tool, resource, and `list_tools` call through a **pipeline** of composable middleware.
+It is a transparent proxy: the client talks to mcpose exactly as it would talk to the upstream, while you intercept, transform, hide, or govern calls in between, without touching the upstream server.
 
-## When to reach for it
-
-- Add cross-cutting behavior (logging, PII redaction, identity resolution, rate limiting) to an MCP server you don't own.
-- Hide or gate specific tools/resources per caller.
-- Resolve a caller **identity** once per session and stamp it on every request.
-- Lay the foundation for compliance-grade audit trails with [`@mcpose/audit`](https://www.npmjs.com/package/@mcpose/audit).
-
-If you only need the audit chain or the compliance test helpers, see the ecosystem packages below; they build on this core.
-
-## Features
-
-- **Transparent proxy**: wrap any upstream MCP server without modifying it.
-- **Composable middleware pipeline** with a predictable onion model: each layer runs before *and* after the inner pipeline.
-- **Per-session identity resolution**: resolve a caller once, then stamp the `Identity` on every request in the session.
-- **Tool and resource governance**: hide or gate specific tools/resources per caller, or pass them straight through the pipeline.
-- **Dual transport**: serve over stdio (lightweight, process-local) or HTTP/SSE with mTLS, session limits, and SSE reconnect replay.
-- **ESM-first**: ships native ESM with first-class TypeScript types.
+This is the core package.
+For tamper-evident audit trails see [`@mcpose/audit`](https://www.npmjs.com/package/@mcpose/audit); for compliance assertions see [`@mcpose/testing`](https://www.npmjs.com/package/@mcpose/testing).
 
 ## Table of Contents
 
@@ -33,19 +20,46 @@ If you only need the audit chain or the compliance test helpers, see the ecosyst
 - [Features](#features)
 - [Install](#install)
 - [Quick start](#quick-start)
+- [Serving over HTTP/SSE](#serving-over-httpsse)
 - [Core concepts](#core-concepts)
 - [API surface](#api-surface)
+  - [Backend config (`BackendConfig`)](#backend-config-backendconfig)
+  - [Proxy options (`ProxyOptions`)](#proxy-options-proxyoptions)
+  - [HTTP options (`HttpProxyOptions`)](#http-options-httpproxyoptions)
+  - [Context and identity](#context-and-identity)
+  - [Rejection reasons](#rejection-reasons)
+  - [Test helpers: `mcpose/testing`](#test-helpers-mcposetesting)
 - [The mcpose ecosystem](#the-mcpose-ecosystem)
 - [Documentation](#documentation)
 - [License](#license)
 
+## When to reach for it
+
+- Add cross-cutting behavior (logging, PII redaction, identity resolution, rate limiting) to an MCP server you do not own.
+- Hide or gate specific tools and resources per caller, with a structured reason rather than an opaque error.
+- Resolve a caller **identity** once per session and read it from every request in that session.
+- Lay the foundation for compliance-grade audit trails with [`@mcpose/audit`](https://www.npmjs.com/package/@mcpose/audit).
+
+If you own the single MCP server and need one hook in one place, a request handler in that server is simpler than a proxy hop.
+mcpose earns its keep when the concern is cross-cutting, the server is not yours, or the behavior has to be tested independently of any one server.
+
+## Features
+
+- **Transparent proxy**: wrap any upstream MCP server without modifying it.
+- **Composable middleware pipeline** with a predictable onion model: each layer runs before *and* after the layers inside it.
+- **Per-session identity resolution**: resolve a caller once, then read the same `Identity` from every request in the session.
+- **Tool and resource governance**: hide tools, gate them per caller, or pass them straight through the pipeline.
+- **Dual transport**: stdio (lightweight, process-local) or HTTP/SSE with mTLS, session limits, and SSE reconnect replay.
+- **ESM-first**: native ESM with first-class TypeScript types, and no runtime dependencies beyond the MCP SDK.
+
 ## Install
 
 ```bash
-npm install mcpose
+npm install mcpose @modelcontextprotocol/sdk
 ```
 
-Requires Node.js 20+. Ships ESM with TypeScript types.
+Requires Node.js 20+.
+`@modelcontextprotocol/sdk` (`^1.17.0`) is a peer dependency you install yourself.
 
 ## Quick start
 
@@ -55,7 +69,7 @@ Connect to an upstream over stdio, add one middleware, and serve the proxy:
 import { createBackendClient, startProxy } from 'mcpose';
 import type { ToolMiddleware } from 'mcpose';
 
-// 1. Connect to the upstream MCP server (stdio)
+// 1. Connect to the upstream MCP server (stdio).
 const backend = await createBackendClient({
   command: 'node',
   args: ['/path/to/backend-server.mjs'],
@@ -69,13 +83,15 @@ const loggingMW: ToolMiddleware = async (req, next) => {
   return result;
 };
 
-// 3. Start the proxy on stdio
-await startProxy(backend, {
-  toolMiddleware: [loggingMW],
-});
+// 3. Start the proxy on stdio.
+await startProxy(backend, { toolMiddleware: [loggingMW] });
 ```
 
-To serve over HTTP instead, with identity resolution, mTLS, session limits, and SSE reconnect replay, use `startHttpProxy`:
+Point your MCP client at this process instead of the upstream, and every tool call flows through `loggingMW`.
+
+## Serving over HTTP/SSE
+
+`startHttpProxy` adds per-session identity resolution, mTLS, session limits, and SSE reconnect replay:
 
 ```ts
 import { createBackendClient, startHttpProxy } from 'mcpose';
@@ -84,7 +100,7 @@ import { createBackendClient, startHttpProxy } from 'mcpose';
 //   extractJwt: a resolveIdentity function returning an Identity from the request
 const backend = await createBackendClient({ url: 'http://localhost:9000/mcp' });
 
-await startHttpProxy(
+const server = await startHttpProxy(
   backend,
   { toolMiddleware: [loggingMW] },
   {
@@ -95,36 +111,49 @@ await startHttpProxy(
 );
 ```
 
-`HttpProxyOptions` also accepts `validateSession(req, { sessionId, identity })` to re-validate an existing session on every routed request (return `false` or throw to reject with 401), plus `allowedHosts`, `allowedOrigins`, and `enableDnsRebindingProtection`, which are forwarded to the SDK transport.
-`onSessionClosed` fires on client DELETE, TTL expiry, and server shutdown.
-Only an `initialize` POST can create a session; a session-less GET or DELETE returns 400.
-Credential-bearing headers (`authorization`, `proxy-authorization`, `cookie`, `set-cookie`, `x-api-key`) are stripped from `ProxyContext.headers` before middleware sees them; `resolveIdentity` still reads the raw request.
+The returned `http.Server` is already listening; call `.close()` to shut down.
+Active proxy sessions are closed before the underlying server finishes closing.
+
+Behavior worth knowing before you deploy it:
+
+- **Session creation is restricted.** Only an `initialize` POST can create a session; a session-less GET or DELETE returns 400.
+- **Sessions can be re-validated per request.** `validateSession(req, { sessionId, identity })` runs on every routed request; return `false` or throw for a 401.
+  Use it to bind a session to its original credential, so a leaked `mcp-session-id` alone cannot take a session over.
+- **Credential headers never reach middleware.** `authorization`, `proxy-authorization`, `cookie`, `set-cookie`, and `x-api-key` are stripped from `ProxyContext.headers`, and with that from anything middleware logs.
+  `resolveIdentity` reads the raw `http.IncomingMessage`, so it still sees them.
+- **`onSessionClosed` fires on every session-end path**: client DELETE, TTL expiry, and server shutdown, so audit manifests flush in all three cases.
+- **Limit breaches are structured.** 503 (session limit) and 413 (body limit) responses carry `error.data.rejectionReason` set to `SESSION_LIMIT` / `BODY_LIMIT`.
+- **SSE replay is scoped per stream.** The in-memory store replays only events from the reconnecting stream; an unknown or already-evicted `Last-Event-ID` replays nothing.
 
 ## Core concepts
 
-- **Middleware**: a single function `(req, next, ctx) => Promise<result>`. Call `next(req)` to delegate downstream; transform the request before, or the response after. Middlewares nest onion-style.
-- **Pipeline**: middlewares passed to `ProxyOptions` run in response-processing order (first = innermost). `[piiMW, auditMW]` redacts before it audits.
-- **ProxyContext**: per-request metadata threaded through the pipeline: `requestId`, `transport`, `sessionId`, resolved `identity`, and the agent `delegatedFrom` chain.
+- **Middleware**: a single function `(req, next, ctx) => Promise<result>`.
+  Call `next(req)` to delegate inward; transform the request before, or the response after.
+  Middlewares nest onion-style.
+- **Pipeline**: middleware passed to `ProxyOptions` runs in **response-processing order**, so the first element processes the response first and is therefore the innermost layer.
+  `[piiMW, auditMW]` redacts before it audits.
+  Note that `compose()` uses the opposite, outermost-first convention, so the two are not interchangeable.
+  See [ADR-0002](https://github.com/amir-gorji/mcpose/blob/main/docs/adr/0002-proxy-options-array-response-processing-order.md).
+- **ProxyContext**: per-request metadata threaded through the pipeline: `requestId`, `transport`, `sessionId`, the resolved `identity`, and the `delegatedFrom` delegation chain.
 
 ## API surface
 
 | Export | Purpose |
 |---|---|
 | `createBackendClient(config)` | Connect to an upstream over stdio (`command`/`args`) or HTTP (`url`). |
-| `startProxy(backend, options?)` | Serve the proxy over **stdio**. |
-| `startHttpProxy(backend, proxyOptions?, httpOptions?)` | Serve over **HTTP/SSE**: identity, mTLS, sessions, reconnect replay. |
-| `createProxyServer(backend, options?)` | Build the underlying `Server` without binding a transport. Throws if the backend is not connected. |
-| `compose(middlewares)` | Compose middlewares into one (outermost-first). |
-| `markPassThroughObserver(mw)` | Mark a middleware (audit, telemetry) to still run for `passThroughTools`. |
-| `rejectionMcpError(reason, code, message)` | Build an `McpError` with a `RejectionReason` in `error.data`. |
-| `createProxyContext(overrides?)` | Construct a `ProxyContext` (useful in tests). |
+| `startProxy(backend, options?)` | Serve the proxy over **stdio**. Resolves when the transport closes. |
+| `startHttpProxy(backend, proxyOptions?, httpOptions?)` | Serve over **HTTP/SSE**: identity, mTLS, sessions, reconnect replay. Resolves with a listening `http.Server`. |
+| `createProxyServer(backend, options?)` | Build the underlying `Server` without binding a transport. Throws if the backend is not connected, so a mis-wired proxy fails at startup rather than on the first call. |
+| `compose(middlewares)` | Compose middleware into one, **outermost-first**. |
+| `markPassThroughObserver(mw)` | Return a new middleware that still runs for `passThroughTools`. For observers only, never transformers. |
+| `rejectionMcpError(reason, code, message)` | Build an `McpError` carrying a `RejectionReason` in `error.data`. |
+| `createProxyContext(overrides?)` | Construct a `ProxyContext`. Useful in tests. |
 | `createInMemoryEventStore()` | Default SSE reconnect event store; swap for a `PersistentEventStore`. |
-| `hasToolContent(result)` | Type guard for tool-call results. |
-
-`PersistentEventStore` is an alias of the SDK's `EventStore` type, so any SDK-compatible store plugs in directly.
-The in-memory store replays events per stream; an unknown or already-evicted `Last-Event-ID` replays nothing.
+| `hasToolContent(result)` | Type guard narrowing `CompatibilityCallToolResult` to `CallToolResult`. |
 
 **Key types:** `Middleware<Req, Res>`, `ToolMiddleware`, `ResourceMiddleware`, `ListToolsMiddleware`, `ProxyContext`, `Identity`, `BackendConfig`, `ProxyOptions`, `HttpProxyOptions`, `RejectionReason`, `TelemetryEvent`, `PersistentEventStore`.
+
+`PersistentEventStore` is an alias of the SDK's `EventStore` type, so any SDK-compatible store plugs in directly.
 
 ### Backend config (`BackendConfig`)
 
@@ -132,14 +161,13 @@ The in-memory store replays events per stream; an unknown or already-evicted `La
 
 | Field | Mode | Description |
 |---|---|---|
-| `command` | stdio | Shell command to spawn the backend (e.g. `"node"`). |
-| `args` | stdio | Args passed to `command` (e.g. `["/path/to/server.mjs"]`). |
+| `command` | stdio | Executable to spawn for the backend (e.g. `"node"`). |
+| `args` | stdio | Arguments passed to `command` (e.g. `["/path/to/server.mjs"]`). |
 | `url` | HTTP/SSE | URL of a running backend. Takes precedence over stdio. |
-| `headers` | HTTP/SSE | Custom HTTP headers sent on every request to the backend. |
-| `authProvider` | HTTP/SSE | `OAuthClientProvider` for interactive/browser OAuth and transparent token refresh. |
+| `headers` | HTTP/SSE | Custom headers sent on every request to the backend. Ignored in stdio mode. |
+| `authProvider` | HTTP/SSE | `OAuthClientProvider` for interactive OAuth with transparent token refresh. Ignored in stdio mode. |
 
-`headers` is HTTP/SSE only and is ignored in stdio mode.
-Use it to authenticate with the upstream, for example an API key or bearer token.
+Use `headers` to authenticate with the upstream using a static credential:
 
 ```ts
 const backend = await createBackendClient({
@@ -148,9 +176,8 @@ const backend = await createBackendClient({
 });
 ```
 
-For backends that require OAuth rather than a static token, pass an `authProvider`.
-mcpose forwards it to the HTTP/SSE transport, which runs the MCP OAuth flow (interactive/browser authorization with transparent token refresh), so you don't manage tokens yourself.
-Like `headers`, it is HTTP/SSE only and ignored in stdio mode.
+For upstreams that require OAuth rather than a static token, pass an `authProvider`.
+mcpose forwards it to the HTTP/SSE transport, which runs the MCP OAuth flow (browser authorization plus transparent refresh) so you do not manage tokens yourself.
 
 ```ts
 import { OAuthClientProvider } from '@modelcontextprotocol/sdk/client/auth';
@@ -159,43 +186,200 @@ const authProvider: OAuthClientProvider = {
   // redirectUrl, clientMetadata, and the token/authorization-code callbacks
 };
 
-const backend = await createBackendClient({
-  url: 'https://mcp.example.com/sse',
-  authProvider,
-});
+const backend = await createBackendClient({ url: 'https://mcp.example.com/sse', authProvider });
 ```
 
-### Governance options (`ProxyOptions`)
+See [`oauth-upstream-client.ts`](https://github.com/amir-gorji/mcpose/blob/main/examples/oauth-upstream-client.ts) for a complete implementation.
 
-`name` and `version` set the MCP server identity returned in `initialize`: `name` defaults to `'mcpose'` and `version` defaults to the mcpose library version, so set your own when you ship a proxy.
-`hiddenTools` / `hiddenResources` reject calls with a structured [`RejectionReason`](https://github.com/amir-gorji/mcpose#rejectionreason) in the MCP error `data` field.
-The hidden-tool rejection is thrown inside the middleware pipeline, so middleware such as audit observes it; the backend is never called.
-`passThroughTools` skip transforming middleware, but middleware wrapped in `markPassThroughObserver()` still runs for them; a tool that is both hidden and pass-through stays hidden.
-`onTelemetry` emits per-call timing and outcome; results with `isError: true` are reported as outcome `'error'`, and a throwing sink never fails the call.
+### Proxy options (`ProxyOptions`)
+
+<details>
+<summary>Show the <code>ProxyOptions</code> interface</summary>
+
+```ts
+interface ProxyOptions {
+  name?:                 string;
+  version?:              string;
+  toolMiddleware?:       ReadonlyArray<ToolMiddleware>;
+  resourceMiddleware?:   ReadonlyArray<ResourceMiddleware>;
+  listToolsMiddleware?:  ReadonlyArray<ListToolsMiddleware>;
+  passThroughTools?:     ReadonlyArray<string>;
+  passThroughResources?: ReadonlyArray<string>;
+  hiddenTools?:          ReadonlyArray<string>;
+  hiddenResources?:      ReadonlyArray<string>;
+  onTelemetry?:          (event: TelemetryEvent) => void;
+}
+```
+
+</details>
+
+- `name` and `version` set the MCP server identity returned in `initialize`.
+  `name` defaults to `'mcpose'` and `version` to the mcpose library version, so set your own when you ship a proxy.
+- `hiddenTools` / `hiddenResources` reject calls with a structured [`RejectionReason`](#rejection-reasons) in the MCP error `data` field.
+  The rejection is thrown *inside* the pipeline, so observing middleware such as audit records it; the upstream is never called.
+- `passThroughTools` / `passThroughResources` skip transforming middleware, but middleware wrapped in `markPassThroughObserver()` still runs for them.
+  A tool that is both hidden and pass-through stays hidden.
+- `onTelemetry` fires after every tool call with timing, outcome, tool name, and identity.
+  Results with `isError: true` are reported as outcome `'error'`, and a throwing sink is logged but never fails the call.
+  An OpenTelemetry adapter (`@mcpose/otel`) is planned for v3.
+
+### HTTP options (`HttpProxyOptions`)
+
+<details>
+<summary>Show the <code>HttpProxyOptions</code> interface and <code>startHttpProxy()</code> signature</summary>
+
+```ts
+interface HttpProxyOptions {
+  port?: number;         // Default: 3000
+  host?: string;         // Default: all interfaces
+  path?: string;         // Default: '/mcp'
+  onRequest?: (req: http.IncomingMessage, res: http.ServerResponse) => boolean | Promise<boolean>;
+  onError?: (err: unknown) => void;
+  maxBodyBytes?: number; // Default: 4 MB (4,194,304); excess returns 413
+  maxSessions?: number;  // Excess requests return 503
+  sessionTtlMs?: number; // Sessions auto-close after this duration
+  /** Resolves caller identity once per session. Errors abort the session with 401. */
+  resolveIdentity?: (req: http.IncomingMessage) => Identity | Promise<Identity>;
+  /** Re-validates an existing session on every routed request. Return false (or throw) for a 401. */
+  validateSession?: (
+    req: http.IncomingMessage,
+    session: { sessionId: string; identity?: Identity },
+  ) => boolean | Promise<boolean>;
+  /** mTLS: Node's https.ServerOptions (key, cert, ca, requestCert, rejectUnauthorized). */
+  tlsOptions?: https.ServerOptions;
+  /** SSE reconnect replay store. Defaults to in-memory. Pass null to disable. */
+  eventStore?: PersistentEventStore | null;
+  /** Called when a session closes: client DELETE, TTL expiry, or server shutdown. */
+  onSessionClosed?: (sessionId: string) => void;
+  /** Hosts allowed in the Host header when DNS-rebinding protection is on. */
+  allowedHosts?: string[];
+  /** Origins allowed in the Origin header. */
+  allowedOrigins?: string[];
+  /** Enables the SDK transport's Host/Origin checks. Recommended for localhost proxies. */
+  enableDnsRebindingProtection?: boolean;
+}
+
+function startHttpProxy(
+  backend: BackendClient,
+  options?: ProxyOptions,
+  httpOptions?: HttpProxyOptions,
+): Promise<http.Server>;
+```
+
+</details>
+
+`httpOptions` is meaningful only for HTTP/SSE transport; omit it when serving over stdio.
+`allowedHosts`, `allowedOrigins`, and `enableDnsRebindingProtection` are forwarded to the SDK transport.
+The behavioral notes in [Serving over HTTP/SSE](#serving-over-httpsse) apply to all of these.
+
+### Context and identity
+
+Every middleware receives a normalized `ProxyContext` as its third argument.
+
+<details>
+<summary>Show <code>ProxyContext</code>, <code>Identity</code>, and the middleware types</summary>
+
+```ts
+interface ProxyContext {
+  requestId: string;
+  transport: 'stdio' | 'http';
+  sessionId?: string;
+  headers?: Readonly<Record<string, string>>;
+  signal?: AbortSignal;
+  /** Resolved caller identity. Present when resolveIdentity is configured. */
+  identity?: Identity;
+  /** Agent delegation chain. Stamped by the host; core does not populate it yet. */
+  delegatedFrom?: Identity[];
+  /** Reserved for the v3 policy engine. */
+  policy?: never;
+}
+
+interface Identity {
+  sub: string;
+  type: 'human' | 'agent' | 'service';
+  displayName?: string;
+  roles: string[];
+  claims: Record<string, unknown>;
+  resolvedAt: string;  // ISO 8601
+  source: 'jwt' | 'mtls' | 'apikey' | 'custom';
+}
+
+type Middleware<Req, Res> = (
+  req: Req,
+  next: (req: Req) => Promise<Res>,
+  context: ProxyContext,
+) => Promise<Res>;
+
+type ToolMiddleware      = Middleware<CallToolRequest, CompatibilityCallToolResult>;
+type ResourceMiddleware  = Middleware<ReadResourceRequest, ReadResourceResult>;
+type ListToolsMiddleware = Middleware<ListToolsRequest, ListToolsResult>;
+```
+
+</details>
+
+`sessionId` is present on HTTP transport only.
+Over stdio there is no session concept, which is why `@mcpose/audit` produces no `ReplayManifest` there.
+
+`delegatedFrom` records agent-to-agent handoffs, but core does not extract it from requests yet: it is populated only when your host application places it on the context.
+A delegation header spec is v3 work.
+
+### Rejection reasons
+
+Every blocked call embeds a `RejectionReason` in the MCP error `data` field.
+The top-level error code is unchanged, so clients that only inspect the code are unaffected, while audit middleware and agents can branch on `error.data.rejectionReason`.
+
+Use `rejectionMcpError(reason, code, message)` to reject from your own middleware in the same structured shape the proxy uses.
+
+<details>
+<summary>Show the <code>RejectionReason</code> union</summary>
+
+```ts
+type RejectionReason =
+  | 'TOOL_HIDDEN'           // tool exists but is hidden from this caller
+  | 'RESOURCE_HIDDEN'       // resource exists but is hidden from this caller
+  | 'POLICY_DENIED'         // v3: RBAC policy blocked the call
+  | 'IDENTITY_UNRESOLVED'   // v3: identity could not be established
+  | 'CONSENT_MISSING'       // v3: GDPR/CCPA consent gate blocked the call
+  | 'SENSITIVITY_BLOCKED'   // v3: data sensitivity policy blocked the call
+  | 'DELEGATION_INVALID'    // v3: agent delegation chain is invalid or expired
+  | 'BUDGET_EXCEEDED'       // v3: cost budget for this session/user exceeded
+  | 'SESSION_LIMIT'         // max concurrent sessions reached (HTTP 503)
+  | 'BODY_LIMIT';           // request body exceeded maxBodyBytes (HTTP 413)
+```
+
+</details>
+
+The values marked v3 are reserved: the union is declared now so that `error.data` consumers written today keep compiling when the policy engine lands.
 
 ### Test helpers: `mcpose/testing`
 
-The core package exposes proxy/middleware test utilities under a subpath:
+The core package exposes proxy and middleware test utilities under a subpath:
 
 ```ts
 import { createMockBackendClient, runToolMiddleware } from 'mcpose/testing';
 ```
 
-> **Not to be confused with** [`@mcpose/testing`](https://www.npmjs.com/package/@mcpose/testing), the separate package of compliance-chain assertions.
+`createMockBackendClient()` returns an in-memory backend stub with capability lookup and notification hooks.
+It works with both `createProxyServer()` and `startHttpProxy()` tests, so an example or test suite needs no real upstream.
+`runToolMiddleware()` drives a single middleware in isolation.
+
+> **Not to be confused with** [`@mcpose/testing`](https://www.npmjs.com/package/@mcpose/testing), a separate package of compliance assertions over audit chains.
+> This subpath mocks the proxy; that package verifies the audit trail.
 
 ## The mcpose ecosystem
 
 | Package | What it adds |
 |---|---|
 | **`mcpose`** (this package) | Proxy core: pipeline, transports, identity, governance. |
-| [`@mcpose/audit`](https://www.npmjs.com/package/@mcpose/audit) | Tamper-evident, HMAC-chained audit events + Merkle `ReplayManifest`. |
-| [`@mcpose/testing`](https://www.npmjs.com/package/@mcpose/testing) | Runner-agnostic compliance assertions for the audit chain. |
+| [`@mcpose/audit`](https://www.npmjs.com/package/@mcpose/audit) | Tamper-evident HMAC-chained audit events and a signed Merkle `ReplayManifest`. |
+| [`@mcpose/testing`](https://www.npmjs.com/package/@mcpose/testing) | Runner-agnostic compliance assertions over an audit trail. |
 
 ## Documentation
 
-- [Full README & API reference](https://github.com/amir-gorji/mcpose#readme)
-- [CONTEXT.md](https://github.com/amir-gorji/mcpose/blob/main/CONTEXT.md): canonical domain glossary
+- [Project README](https://github.com/amir-gorji/mcpose#readme): concepts, comparison, guides, and examples
+- [`CONTEXT.md`](https://github.com/amir-gorji/mcpose/blob/main/CONTEXT.md): the canonical domain glossary
 - [Architecture decision records](https://github.com/amir-gorji/mcpose/tree/main/docs/adr)
+- [Runnable examples](https://github.com/amir-gorji/mcpose/tree/main/examples)
 
 ## License
 

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -2,40 +2,53 @@
 
 [![npm](https://img.shields.io/npm/v/@mcpose/testing)](https://www.npmjs.com/package/@mcpose/testing)
 [![license](https://img.shields.io/npm/l/@mcpose/testing)](https://github.com/amir-gorji/mcpose/blob/main/LICENSE)
+[![node](https://img.shields.io/node/v/@mcpose/testing)](https://nodejs.org/)
 [![TypeScript](https://img.shields.io/badge/TypeScript-6.x-blue)](https://www.typescriptlang.org/)
 [![CI](https://github.com/amir-gorji/mcpose/actions/workflows/ci.yml/badge.svg)](https://github.com/amir-gorji/mcpose/actions/workflows/ci.yml)
 
 **Compliance assertions for [`@mcpose/audit`](https://www.npmjs.com/package/@mcpose/audit) audit chains.**
 
-A small set of assertion functions that verify the tamper-evidence guarantees of an mcpose audit trail: chain integrity, Merkle-proof validity, PII redaction, and delegation handling. Each throws a descriptive `Error` on failure and returns `void` on success.
+Four assertion functions that verify the tamper-evidence properties of an mcpose audit trail: chain integrity, Merkle-proof validity, PII redaction, and delegation handling.
+Each throws a descriptive `Error` on failure and returns `void` on success.
 
-**These assertions are deliberately keyless** — the signing secret is not available to tests. They prove the artifact is internally consistent: they catch reordering, renumbering, duplication, head or middle deletion, and a swapped Merkle root. They do not prove it is authentic. A forger who rewrites every event and regenerates the root and proofs produces a document these assertions accept, and does not need the signing secret to do it. Deleting from the tail also leaves a valid prefix, so `assertAuditChainIntegrity` alone accepts it; `manifest.eventCount` is what catches that. For keyed verification, use `verifyAuditChain(events, signingKey)` and `verifyManifestSignature(manifest, signingKey)` from `@mcpose/audit`.
+They are plain functions with no test-framework dependency, so they work with Vitest, Jest, `node:test`, or any runner.
 
-**Runner-agnostic.** These are plain functions with no test-framework dependency; use them with Vitest, Jest, `node:test`, or any runner.
-
-> **Not to be confused with** `mcpose/testing`: the subpath export of the **core** `mcpose` package, which provides proxy/middleware mocks (`createMockBackendClient`, `runToolMiddleware`). This package (`@mcpose/testing`) is about asserting the **audit chain**.
-
-## When to reach for it
-
-You have an `@mcpose/audit` audit trail and need to verify in your test suite that the chain is intact, Merkle proofs are valid, PII fields are redacted, and agent delegation chains are honored, without coupling your tests to a specific test framework.
-
-## Features
-
-- **Chain structure verification**: `assertAuditChainIntegrity` checks sequential positions and distinct, non-empty chain hashes (catches reordering, renumbering, duplicates; throws on an empty chain). It does not recompute HMACs — use `verifyAuditChain` for that.
-- **Manifest consistency**: `assertReplayManifestValid` recomputes the Merkle root from the events under test, requires one proof per event, and verifies every proof at its index. It does not check the manifest signature — use `verifyManifestSignature`.
-- **PII redaction checks**: `assertPiiRedacted` confirms no sensitive patterns appear in plaintext low/medium events; high-tier events are structurally checked (no plaintext fields, encrypted payloads present) — their content is ciphertext and is not pattern-scanned.
-- **Delegation chain validation**: `assertDelegationHonored(event)` ensures the event carries a non-empty `delegatedFrom` chain whose entries have a `sub`. Signatures and continuity are v3.
-- **Runner-agnostic**: plain functions with no test-framework dependency; use with Vitest, Jest, `node:test`, or any runner.
+> **Not to be confused with** `mcpose/testing`, the subpath export of the **core** `mcpose` package, which provides proxy and middleware mocks (`createMockBackendClient`, `runToolMiddleware`).
+> That subpath mocks the proxy; this package asserts the **audit chain**.
 
 ## Table of Contents
 
+- [What these assertions prove](#what-these-assertions-prove)
 - [When to reach for it](#when-to-reach-for-it)
-- [Features](#features)
 - [Install](#install)
 - [Quick start](#quick-start)
 - [API](#api)
 - [Documentation](#documentation)
 - [License](#license)
+
+## What these assertions prove
+
+Read this before relying on them in a compliance suite.
+
+**These assertions are deliberately keyless**, because the signing secret is not available to tests.
+They prove an audit artifact is **internally consistent**: they catch reordering, renumbering, duplication, head or middle deletion, and a swapped Merkle root.
+
+**They do not prove it is authentic.**
+A forger who rewrites every event and regenerates the root and proofs produces a document these assertions accept, and does not need the signing secret to do it, because the forger supplies the hashes.
+Deleting from the tail also leaves a valid prefix, so `assertAuditChainIntegrity` alone accepts it; `manifest.eventCount` is what catches that.
+
+For authenticity, use the **keyed** verifiers from `@mcpose/audit` wherever the secret is available:
+
+```ts
+import { verifyAuditChain, verifyManifestSignature } from '@mcpose/audit';
+```
+
+The right mental model: these assertions are a *structural regression guard* for your pipeline, catching the day someone reorders middleware or drops events on the floor.
+They are not the thing you hand a regulator.
+
+## When to reach for it
+
+You have an `@mcpose/audit` trail and need your test suite to fail when the chain stops being intact, Merkle proofs stop verifying, PII leaks into a plaintext tier, or a delegation chain goes missing, without coupling the tests to a specific test framework.
 
 ## Install
 
@@ -43,17 +56,17 @@ You have an `@mcpose/audit` audit trail and need to verify in your test suite th
 npm install --save-dev @mcpose/testing
 ```
 
+Requires Node.js 20+.
 `mcpose` and `@mcpose/audit` are peer dependencies.
 
 ## Quick start
 
 ```ts
-import { expect, test } from 'vitest'; // or jest, node:test, your choice
+import { test } from 'vitest'; // or jest, node:test, your choice
 import {
   assertAuditChainIntegrity,
   assertReplayManifestValid,
   assertPiiRedacted,
-  assertDelegationHonored,
 } from '@mcpose/testing';
 
 // Supplied by your test setup:
@@ -64,28 +77,36 @@ test('transfer flow produces a verifiable audit trail', async () => {
   const events = await captureAuditEvents(/* run your scenario */);
   const manifest = await auditHandle.closeSession('session-123');
 
-  assertAuditChainIntegrity(events);                 // positions sequential, hashes distinct, non-empty
-  assertReplayManifestValid(events, manifest!);      // every Merkle proof verifies
-  assertPiiRedacted(events[0], [/\d{16}/]);          // no card numbers in plaintext
+  assertAuditChainIntegrity(events);            // positions sequential, hashes distinct and non-empty
+  assertReplayManifestValid(events, manifest!); // every Merkle proof verifies against the root
+  assertPiiRedacted(events[0], [/\d{16}/]);     // no card numbers in plaintext
 });
 ```
+
+`closeSession` returns `undefined` for an unknown session or one with no events, which is why the example asserts on `manifest!`.
+If a manifest is expected, assert that it exists rather than asserting through it.
 
 ## API
 
 | Function | Proves | Does NOT prove |
 |---|---|---|
-| `assertAuditChainIntegrity(events)` | Positions sequential; `chainHash`es distinct and non-empty; non-empty log | Authenticity. No HMAC is recomputed, so any self-consistent rewrite passes — and it does not have to be key-consistent, because the forger supplies the hashes. Tail truncation also passes; the manifest's `eventCount` is what catches it |
-| `assertReplayManifestValid(events, manifest)` | Root recomputes from the events; one proof per event; every proof verifies at its index | The manifest **signature** — use `verifyManifestSignature` |
-| `assertPiiRedacted(event, patterns)` | low/medium: no pattern matches plaintext; high: no plaintext fields, encrypted payloads present | Anything about what is inside high-tier ciphertext |
-| `assertDelegationHonored(event)` | `delegatedFrom` present, non-empty, entries have a `sub` | Delegation signatures or chain continuity (v3) |
+| `assertAuditChainIntegrity(events)` | The log is non-empty; positions are sequential; `chainHash`es are distinct and non-empty. | Authenticity. No HMAC is recomputed, so any self-consistent rewrite passes, and it need not be key-consistent because the forger supplies the hashes. Tail truncation also passes; the manifest's `eventCount` is what catches it. |
+| `assertReplayManifestValid(events, manifest)` | `eventCount` matches; the root recomputes from the events under test; one proof per event; every proof verifies at its own index. | The manifest **signature**. Use `verifyManifestSignature`. |
+| `assertPiiRedacted(event, patterns)` | low/medium: no pattern matches the plaintext fields. high: no plaintext fields present, and encrypted payloads are. | Anything about the content of high-tier ciphertext, which is never pattern-scanned. |
+| `assertDelegationHonored(event)` | `delegatedFrom` is present and non-empty, and every entry has a `sub`. | Delegation signatures or chain continuity, which are v3. |
 
-Re-exports `AuditEvent` and `ReplayManifest` types from `@mcpose/audit` for convenience.
+Two notes that trip people up:
+
+- `assertAuditChainIntegrity` **throws on an empty chain**, deliberately: a log truncated to zero events must not pass a compliance assertion. If an empty session is the expected outcome, assert that explicitly instead.
+- `assertDelegationHonored` only passes when your host application stamps `delegatedFrom` onto the `ProxyContext`. mcpose core does not populate it yet; a delegation header spec is v3 work.
+
+The package also re-exports the `AuditEvent` and `ReplayManifest` types from `@mcpose/audit` for convenience.
 
 ## Documentation
 
-- [Full README & API reference](https://github.com/amir-gorji/mcpose#mcposetesting)
+- [Project README](https://github.com/amir-gorji/mcpose#readme): concepts, comparison, and guides
 - [`@mcpose/audit`](https://www.npmjs.com/package/@mcpose/audit): the package these helpers verify
-- [CONTEXT.md](https://github.com/amir-gorji/mcpose/blob/main/CONTEXT.md): canonical domain glossary
+- [`CONTEXT.md`](https://github.com/amir-gorji/mcpose/blob/main/CONTEXT.md): the canonical domain glossary
 
 ## License
 

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -64,7 +64,7 @@ test('transfer flow produces a verifiable audit trail', async () => {
   const events = await captureAuditEvents(/* run your scenario */);
   const manifest = await auditHandle.closeSession('session-123');
 
-  assertAuditChainIntegrity(events);                 // no insert/delete/reorder
+  assertAuditChainIntegrity(events);                 // positions sequential, hashes distinct, non-empty
   assertReplayManifestValid(events, manifest!);      // every Merkle proof verifies
   assertPiiRedacted(events[0], [/\d{16}/]);          // no card numbers in plaintext
 });
@@ -74,7 +74,7 @@ test('transfer flow produces a verifiable audit trail', async () => {
 
 | Function | Proves | Does NOT prove |
 |---|---|---|
-| `assertAuditChainIntegrity(events)` | Positions sequential; `chainHash`es distinct and non-empty; non-empty log | HMAC validity (no key) — a key-consistent forgery passes |
+| `assertAuditChainIntegrity(events)` | Positions sequential; `chainHash`es distinct and non-empty; non-empty log | Authenticity. No HMAC is recomputed, so any self-consistent rewrite passes — and it does not have to be key-consistent, because the forger supplies the hashes. Tail truncation also passes; the manifest's `eventCount` is what catches it |
 | `assertReplayManifestValid(events, manifest)` | Root recomputes from the events; one proof per event; every proof verifies at its index | The manifest **signature** — use `verifyManifestSignature` |
 | `assertPiiRedacted(event, patterns)` | low/medium: no pattern matches plaintext; high: no plaintext fields, encrypted payloads present | Anything about what is inside high-tier ciphertext |
 | `assertDelegationHonored(event)` | `delegatedFrom` present, non-empty, entries have a `sub` | Delegation signatures or chain continuity (v3) |

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -9,7 +9,7 @@
 
 A small set of assertion functions that verify the tamper-evidence guarantees of an mcpose audit trail: chain integrity, Merkle-proof validity, PII redaction, and delegation handling. Each throws a descriptive `Error` on failure and returns `void` on success.
 
-**These assertions are deliberately keyless** — the signing secret is not available to tests. They catch structural tampering (reordering, renumbering, duplicated or missing entries, doctored roots), but a key-holder forging a consistent chain can only be caught by the keyed verifiers in `@mcpose/audit`: `verifyAuditChain` and `verifyManifestSignature`.
+**These assertions are deliberately keyless** — the signing secret is not available to tests. They prove the artifact is internally consistent: they catch reordering, renumbering, duplication, head or middle deletion, and a swapped Merkle root. They do not prove it is authentic. A forger who rewrites every event and regenerates the root and proofs produces a document these assertions accept, and does not need the signing secret to do it. Deleting from the tail also leaves a valid prefix, so `assertAuditChainIntegrity` alone accepts it; `manifest.eventCount` is what catches that. For keyed verification, use `verifyAuditChain(events, signingKey)` and `verifyManifestSignature(manifest, signingKey)` from `@mcpose/audit`.
 
 **Runner-agnostic.** These are plain functions with no test-framework dependency; use them with Vitest, Jest, `node:test`, or any runner.
 

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -10,10 +10,13 @@ export type { AuditEvent, ReplayManifest };
  * pass a compliance assertion.
  *
  * This check is deliberately KEYLESS (the signing secret is not available
- * to tests): it catches reordering, renumbering, and duplicated entries,
- * but NOT a forgery rewritten consistently by a key-holder — for that,
- * recompute the chain with `verifyAuditChain(events, signingKey)` from
- * `@mcpose/audit`.
+ * to tests): it catches reordering, renumbering, duplicated entries, and
+ * head or middle deletion. It does NOT prove authenticity — a forger who
+ * rewrites every event and regenerates the chain hashes produces a document
+ * these checks accept without needing the signing secret at all. Tail
+ * truncation also passes this check alone; the manifest's `eventCount`
+ * is what catches it. For keyed verification, use
+ * `verifyAuditChain(events, signingKey)` from `@mcpose/audit`.
  */
 export function assertAuditChainIntegrity(events: AuditEvent[]): void {
   if (events.length === 0) {


### PR DESCRIPTION
Documentation only. Two concepts, one branch.

## 1. Record what is unreleased

`CHANGELOG.md`'s `[Unreleased]` section was empty while three breaking changes sat on `main` (`@mcpose/audit` format v2, strengthened `@mcpose/testing` assertions, `mcpose` 2.2.0). A reader would conclude 2.1.1 was current. It also notes why this is urgent: `packages/audit` peers `mcpose >= 2.2.0`, which is unpublished, so the working tree is not installable from the registry until all three ship together.

## 2. Rewrite the READMEs

The root README declared the package READMEs canonical, then reproduced ~350 lines of them inline. Every export now has one home: core owns `ProxyOptions` / `HttpProxyOptions` / `ProxyContext` / `RejectionReason`, audit owns `AuditEvent` / `ReplayManifest` / `AuditOptions`. Root drops from 816 to 424 lines; total across all five is flat (1295 to 1330), so this is relocation, not deletion.

Also: adds a comparison section (the "should I use this instead of what I have?" question was unanswered), moves the proxy diagram above the fold, drops "New in 2.0" as a changelog masquerading as a feature list, and reorders to Standard Readme.

## Corrected claims

Verified empirically against the published 2.0.3 packages, and wrong in the unreleased 3.0.0 too, so corrected outright rather than version-fenced:

- **A forgery needs no key at all.** "A key-consistent forgery passes" understates it: rewrite every event, recompute the root and proofs with the real `@mcpose/audit`, and both assertions accept it. The forger supplies the hashes.
- **Tail truncation is not caught.** Head and middle deletion renumber what follows and are caught; truncating the tail leaves a valid prefix that `assertAuditChainIntegrity` accepts alone. `manifest.eventCount` is what catches it.
- **`keyId` was documented as `sha256(secret)`.** That is the v1 derivation ADR-0004 replaced, precisely because a bare digest let anyone holding a manifest brute-force a low-entropy secret offline. The docs were publishing the shape of a fixed vulnerability.
- **`delegatedFrom` read as if core populates it.** It does not; the host stamps it onto the `ProxyContext`. A delegation header spec is v3.

## Out of scope

No code changes. `main` already implements the stronger assertion behaviour, so the gap was a release that has not happened plus a missing docs record, not a bug. Publishing 3.0.0 was considered and declined.

Worth noting for later: `verify.ts` imports from `middleware.ts`, which imports `mcpose` at runtime, so a verifier-only install still pulls in the proxy core.

## Verification

- Every internal link and anchor across all five READMEs resolves.
- Every API-table entry checked against the actual export barrels.
- Tamper-evidence wording checked against `docs/adr/0003`, `0004`, and `CONTEXT.md`.
- Prettier not applied to markdown: it is not in CI and the pre-existing files do not conform, so it would churn the diff rather than fix a regression.